### PR TITLE
Add dependabot for upgrading all own dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+# Update Go dependencies and GitHub Actions dependencies weekly.
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    all:
+      patterns: ["*"]
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    all:
+      patterns: ["*"]


### PR DESCRIPTION
Adds a dependabot configuration to keep all the dependencies in [makefile-modules](https://github.com/cert-manager/makefile-modules) up-to-date.