### PR TITLE
Fix bug in self-upgrade script

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -67,7 +67,7 @@ jobs:
             const pulls = await github.rest.pulls.list({
               owner: owner,
               repo: repo,
-              head: 'self-upgrade',
+              head: owner + ':self-upgrade',
               base: 'main',
               state: 'open',
             });


### PR DESCRIPTION
There is a bug in the self-upgrade script, the script succeeds but does not create a PR (see https://github.com/inteon/approver-policy/actions/runs/7251155494/job/19752903084).
This is because the GH API requires the head parameter to also contain the organisation where the branch lives.

This is an example of a successful run and the created PR:
This is an example run: https://github.com/inteon/approver-policy/actions/runs/7251155494
The created PR: https://github.com/inteon/approver-policy/pull/1