### PR TITLE
Upgrade setup-go GH action step

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 


### PR DESCRIPTION
Use `actions/setup-go@v5` instead of `actions/setup-go@v4`.

see https://github.com/actions/setup-go/releases/tag/v5.0.0 for details

NOTE: it seems like dependabot does not find this version bump, because the github action lives in a sub-directory?