### PR TITLE
Include version in the cert-manager yaml file name

### DIFF
--- a/modules/cert-manager/01_mod.mk
+++ b/modules/cert-manager/01_mod.mk
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cert_manager_crds := $(bin_dir)/scratch/cert-manager-crds.yaml
+cert_manager_crds := $(bin_dir)/scratch/cert-manager-$(cert_manager_version).yaml
 $(cert_manager_crds): | $(bin_dir)/scratch
 	curl -sSLo $@ https://github.com/cert-manager/cert-manager/releases/download/$(cert_manager_version)/cert-manager.crds.yaml


### PR DESCRIPTION
To prevent a stale yaml file from being used, we should include the `cert_manager_version` variable in the filename.
This will cause the file to be re-downloaded when `cert_manager_version` changes.