### PR TITLE
Add images-learn-sha target and improve sha tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,32 @@ SHELL := /usr/bin/env bash
 .SUFFIXES:
 FORCE:
 
+HOST_OS ?= $(shell uname -s | tr A-Z a-z)
+HOST_ARCH ?= $(shell uname -m)
+ifeq (x86_64, $(HOST_ARCH))
+	HOST_ARCH = amd64
+endif
+
 bin_dir := _bin
 
-$(bin_dir):
+$(bin_dir) $(bin_dir)/scratch:
 	mkdir -p $@
 
-include modules/tools/00_mod.mk
+include modules/**/00_mod.mk
+
+.PHONY: images-learn-sha
+images-learn-sha: $(bin_dir) | $(NEEDS_CRANE)
+	rm -rf ./$(bin_dir)/downloaded/images/
+	mkdir -p ./$(bin_dir)/scratch/
+
+	IMAGES_AMD64="$(images_amd64)" \
+	IMAGES_ARM64="$(images_arm64)" \
+	CRANE=$(CRANE) \
+		./scripts/images_learn_sha.sh
 
 .PHONY: help
 help: ## Show this help
 	@echo "Usage: make [target] ..."
 	@echo
 	@echo "make tools-learn-sha"
+	@echo "make images-learn-sha"

--- a/modules/cert-manager/00_mod.mk
+++ b/modules/cert-manager/00_mod.mk
@@ -22,7 +22,7 @@ images_amd64 += quay.io/jetstack/cert-manager-cainjector:$(cert_manager_version)
 images_amd64 += quay.io/jetstack/cert-manager-webhook:$(cert_manager_version)@sha256:292facf28fd4f0db074fed12437669eef9c0ab8c1b9812d2c91e42b4a7448a36
 images_amd64 += quay.io/jetstack/cert-manager-ctl:$(cert_manager_version)@sha256:5c985c4ebd8da6592cbe0249936f7513c0527488d754198699b3be9389b8b587
 
-images_arm64 += quay.io/jetstack/cert-manager-controller:$(cert_manager_version)@sha256:3a218da3db0b05bf487729b07374662b73805a44e6568a2661bba659b22110b2
+images_arm64 += quay.io/jetstack/cert-manager-controller:$(cert_manager_version)@sha256:f2adb86c11c305dcb78607cdf86fa232e657d196f82d0592799aebbfea22dec8
 images_arm64 += quay.io/jetstack/cert-manager-cainjector:$(cert_manager_version)@sha256:118b985b0f0051ee9c428a3736c47bea92c3d8e7cb7c6eda881f7ecd4430cbed
 images_arm64 += quay.io/jetstack/cert-manager-webhook:$(cert_manager_version)@sha256:0195441dc0f7f81e7514e6497bf68171bc54ef8481efc5fa0efe51892bd28c36
 images_arm64 += quay.io/jetstack/cert-manager-ctl:$(cert_manager_version)@sha256:f376994ae17c519b12dd59c406a0abf8c6265c5f0c57431510eee15eaa40e4eb

--- a/modules/kind/00_mod.mk
+++ b/modules/kind/00_mod.mk
@@ -15,5 +15,7 @@
 images_amd64 ?=
 images_arm64 ?=
 
-images_amd64 += docker.io/kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde
-images_arm64 += docker.io/kindest/node:v1.27.3@sha256:de0b3dfe848ccf07e24f4278eaf93edb857b6231b39773f46b36a2b1a6543ae9
+kind_version := v1.27.3
+
+images_amd64 += docker.io/kindest/node:$(kind_version)@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde
+images_arm64 += docker.io/kindest/node:$(kind_version)@sha256:de0b3dfe848ccf07e24f4278eaf93edb857b6231b39773f46b36a2b1a6543ae9

--- a/modules/kind/kind-image-preload.mk
+++ b/modules/kind/kind-image-preload.mk
@@ -37,7 +37,7 @@ $(images_tars): $(images_tar_dir)/%.tar: | $(NEEDS_CRANE)
 	@$(eval image_without_digest=$(shell cut -d@ -f1 <<<"$(image)"))
 	@$(eval digest=$(subst $(image_without_digest)@,,$(image)))
 	@mkdir -p $(dir $@)
-	diff <(echo "$(digest)  -" | cut -d: -f2) <($(CRANE) manifest $(image) | sha256sum)
+	diff <(echo "$(digest)  -" | cut -d: -f2) <($(CRANE) manifest --platform=linux/$(HOST_ARCH) $(image_without_digest) | sha256sum)
 	$(CRANE) pull $(image_without_digest) $@ --platform=linux/$(HOST_ARCH)
 
 images_tar_envs := $(images_files:%=env-%)

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -472,13 +472,13 @@ tools: $(TOOLS_PATHS) $(K8S_CODEGEN_TOOLS_PATHS)
 
 self_file := $(dir $(lastword $(MAKEFILE_LIST)))/00_mod.mk
 
+# This target is used to learn the sha256sum of the tools. It is used only
+# in the makefile-modules repo, and should not be used in any other repo.
 .PHONY: tools-learn-sha
-## re-download all tools and learn the sha values, useful after upgrading
-## @category [shared] Tools
 tools-learn-sha: | $(bin_dir)
 	rm -rf ./$(bin_dir)/
 	mkdir -p ./$(bin_dir)/scratch/
-	$(eval export LEARN_FILE=$(CURDIR)/$(bin_dir)/scratch/learn_file)
+	$(eval export LEARN_FILE=$(CURDIR)/$(bin_dir)/scratch/learn_tools_file)
 	echo -n "" > "$(LEARN_FILE)"
 
 	HOST_OS=linux HOST_ARCH=amd64 $(MAKE) tools

--- a/scripts/images_learn_sha.sh
+++ b/scripts/images_learn_sha.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+images_amd64=${IMAGES_AMD64}
+images_arm64=${IMAGES_ARM64}
+CRANE=${CRANE}
+
+if [ -z "$images_amd64" ]; then
+    echo "IMAGES_AMD64 is not set"
+    exit 1
+fi
+
+if [ -z "$images_arm64" ]; then
+    echo "IMAGES_ARM64 is not set"
+    exit 1
+fi
+
+if [ -z "$CRANE" ]; then
+    echo "CRANE is not set"
+    exit 1
+fi
+
+learn_data=()
+
+for image in $images_amd64; do
+    image_no_digest=$(echo -n "$image" | cut -d@ -f1)
+    find=$(echo -n "$image" | cut -d@ -f2)
+    replace=$($CRANE digest --platform "linux/amd64" "$image_no_digest")
+
+    if [ "$find" == "$replace" ]; then
+        continue
+    fi
+
+    learn_data+=("s|$find|$replace|g\n")
+done
+
+for image in $images_arm64; do
+    image_no_digest=$(echo -n "$image" | cut -d@ -f1)
+    find=$(echo -n "$image" | cut -d@ -f2)
+    replace=$($CRANE digest --platform "linux/arm64" "$image_no_digest")
+
+    if [ "$find" == "$replace" ]; then
+        continue
+    fi
+
+    learn_data+=("s|$find|$replace|g\n")
+done
+
+module_files=$(find ./modules/ -maxdepth 2 -name "00_mod.mk" -type f)
+
+# Don't replace the digests of the kind images
+module_files=$(echo "$module_files" | grep -v "docker.io/kindest/node")
+
+for replace in "${learn_data[@]}"; do
+    for file in $module_files; do
+        sed -i "$replace" "$file";
+    done
+done


### PR DESCRIPTION
- improves image hash checking (based on https://github.com/cert-manager/cert-manager/pull/6440)
- removes `tools-learn-sha` from help of projects that import the `tools` module; because the target should only be used in this repo.
- adds `images-learn-sha` target