### PR TITLE
Fix bug in help regex

### DIFF
--- a/modules/help/help.sh
+++ b/modules/help/help.sh
@@ -24,7 +24,7 @@ PURPLE=$(tput setaf 125)
 EMPTYLINE_REGEX="^\s*$"
 DOCBLOCK_REGEX="^##\s*(.*)$"
 CATEGORY_REGEX="^##\s*@category\s*(.*)$"
-TARGET_REGEX="^([a-zA-Z0-9%_\/%-\$\(\)]+):.*$"
+TARGET_REGEX="^([a-zA-Z0-9\_\/\%\$\-\(\)]+):.*$"
 
 EMPTY_ITEM="<start-category><end-category><start-target><end-target><start-comment><end-comment>"
 


### PR DESCRIPTION
I got the following error:
```
$ make 
grep: Invalid range end
make: *** [make/_shared/help/01_mod.mk:20: help] Error 2
```

This PR fixes that issue.