### PR TITLE
Add an autobumper for the vendored Go version

### DIFF
--- a/.github/workflows/go-auto-upgrade.yaml
+++ b/.github/workflows/go-auto-upgrade.yaml
@@ -1,0 +1,74 @@
+name: auto-go-upgrade
+concurrency: auto-go-upgrade
+on:
+  workflow_dispatch: {}
+  schedule:
+    # 10pm daily
+    - cron: '0 22 * * *'
+
+jobs:
+  go_upgrade_pr:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fail if branch is not main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "This workflow should not be run on a branch other than main."
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - run: |
+          git checkout -B "go-version-bump"
+          ./scripts/patch_go_version.sh
+
+      - id: is-up-to-date
+        shell: bash
+        run: |
+          git_status=$(git status -s)
+          is_up_to_date="true"
+          if [ -n "$git_status" ]; then
+              is_up_to_date="false"
+              echo "The following changes will be committed:"
+              echo "$git_status"
+          fi
+          echo "result=$is_up_to_date" >> "$GITHUB_OUTPUT"
+
+      - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
+        run: |
+          git config --global user.name "jetstack-bot"
+          git config --global user.email "jetstack-bot@users.noreply.github.com"
+          git commit -a -m "BOT: update vendored go to latest available patch version" --signoff
+          git push -f origin go-version-bump
+
+      - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
+        uses: actions/github-script@v7
+        with:
+        script: |
+          const { repo, owner } = context.repo;
+
+          const pulls = await github.rest.pulls.list({
+            owner: owner,
+            repo: repo,
+            head: owner + ':go-version-bump',
+            base: 'main',
+            state: 'open',
+          });
+
+          if (pulls.data.length < 1) {
+            await github.rest.pulls.create({
+              title: '[CI] Bump vendored Go version to latest patch version',
+              owner: owner,
+              repo: repo,
+              head: 'go-version-bump',
+              base: 'main',
+              body: [
+                'This PR is auto-generated to bump the vendored go version in the tools module to the latest available patch version',
+              ].join('\n'),
+            });
+          }

--- a/scripts/patch_go_version.sh
+++ b/scripts/patch_go_version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+TMPDIR=$(mktemp -d)
+
+trap 'rm -f -- "$TMPDIR"' EXIT
+
+# Download version data
+curl --silent --show-error --fail --location --retry 10 --retry-connrefused https://go.dev/dl/?mode=json > $TMPDIR/version.json
+
+LOCAL_VERSION=$(make print-go-version | cut -d= -f2)
+
+MAJOR_MINOR_VERSION=$(echo "$LOCAL_VERSION" | grep -Eo "[0-9]+.[0-9]+")
+
+NEW_VERSION=$(<$TMPDIR/version.json jq -r ".[] | select(.version? | match(\"$MAJOR_MINOR_VERSION.*\")) | .version | sub(\"go\";\"\")")
+
+# Don't want to update a minor version - only want to update patch versions!
+if [[ $NEW_VERSION == "" ]]; then
+	echo "failed to fetch the latest version of go $MAJOR_MINOR_VERSION.*"
+	echo "this could mean the go version is very old or that go versioning has changed"
+	exit 1
+fi
+
+# Check if there's nothing to do
+if [[ $NEW_VERSION == $LOCAL_VERSION ]]; then
+	echo "go version is up to date; exiting"
+	exit 0
+fi
+
+TARGET=modules/tools/00_mod.mk
+
+echo "updating go version to $NEW_VERSION in $TARGET"
+
+sed -i '' "s/^VENDORED_GO_VERSION := $LOCAL_VERSION$/VENDORED_GO_VERSION := $NEW_VERSION/" $TARGET


### PR DESCRIPTION
This only attempts to bump patch versions, leaving us free to make the choice of when to bump the minor version