### PR TITLE
Fix bug in 'make help' grep (second try)

### DIFF
--- a/modules/help/help.sh
+++ b/modules/help/help.sh
@@ -21,9 +21,9 @@ CATEGORY_COLOR="$(tput setaf 3)"
 CLEAR_STYLE="$(tput sgr0)"
 PURPLE=$(tput setaf 125)
 
-EMPTYLINE_REGEX="^\s*$"
-DOCBLOCK_REGEX="^##\s*(.*)$"
-CATEGORY_REGEX="^##\s*@category\s*(.*)$"
+EMPTYLINE_REGEX="^[[:space:]]*$"
+DOCBLOCK_REGEX="^##[[:space:]]*(.*)$"
+CATEGORY_REGEX="^##[[:space:]]*@category[[:space:]]*(.*)$"
 TARGET_REGEX="^(([a-zA-Z0-9\_\/\%\$\(\)]|-)+):.*$"
 
 EMPTY_ITEM="<start-category><end-category><start-target><end-target><start-comment><end-comment>"

--- a/modules/help/help.sh
+++ b/modules/help/help.sh
@@ -24,7 +24,7 @@ PURPLE=$(tput setaf 125)
 EMPTYLINE_REGEX="^\s*$"
 DOCBLOCK_REGEX="^##\s*(.*)$"
 CATEGORY_REGEX="^##\s*@category\s*(.*)$"
-TARGET_REGEX="^([a-zA-Z0-9\_\/\%\$\-\(\)]+):.*$"
+TARGET_REGEX="^(([a-zA-Z0-9\_\/\%\$\(\)]|-)+):.*$"
 
 EMPTY_ITEM="<start-category><end-category><start-target><end-target><start-comment><end-comment>"
 


### PR DESCRIPTION
In https://github.com/cert-manager/makefile-modules/pull/21, I tried to fix a bug in the 'make help' target.
I did fix the error message, but also broke the help output (this output is now missing certain targets containing -).
This PR should actually fix the issue.
before:
```
$ make
Usage: make [target1] [target2] ...

[shared] Tools
    tools                     > Download and setup all tools
    clean                     > Clean all temporary files

[shared] Release
    release                   > Publish all release artifacts (image + helm chart)

[shared] Generate/ Verify
    verify                    > Verify code and generate targets.
    generate                  > Generate all generate targets.

[shared] Build
    $(run_targets)            > Directly run the go source locally.
    $(oci_push_targets)       > Build and push OCI image.
                                If the tag already exists, this target will overwrite it.
                                If an identical image was already built before, we will add a new tag to it, but we will not sign it again.
                                Expected pushed images:
                                - :v1.2.3, @sha256:0000001
                                - :v1.2.3.sig, :sha256-0000001.sig
    $(oci_maybe_push_targets) > Run 'make oci-push-...' if tag does not already exist in registry.
    $(oci_load_targets)       > Build OCI image for the local architecture and load
                                it into the $(kind_cluster_name) kind cluster.
    $(oci_build_targets)      > Build the OCI image.
    $(build_targets)          > Build the go source locally for development/ testing
                                on the local platform.
```
after:
```
$ make
Usage: make [target1] [target2] ...

[shared] Tools
    which-go                  > Print the version and path of go which will be used for building and
                                testing in Makefile commands. Vendored go will have a path in ./bin
    vendor-go                 > By default, this Makefile uses the system's Go. You can use a "vendored"
                                version of Go that will get downloaded by running this command once. To
                                disable vendoring, run "make unvendor-go". When vendoring is enabled,
                                you will want to set the following:
                                
                                export PATH="$PWD/$(bin_dir)/tools:$PATH"
                                export GOROOT="$PWD/$(bin_dir)/tools/goroot"
    tools                     > Download and setup all tools
    clean                     > Clean all temporary files

[shared] Self-upgrade
    upgrade-klone             > Upgrade klone Makefile modules to latest version

[shared] Release
    release                   > Publish all release artifacts (image + helm chart)
    dryrun-release            > Dry-run release process

[shared] Generate/ Verify
    verify                    > Verify code and generate targets.
    verify-boilerplate        > Verify that all files have the correct boilerplate.
    generate                  > Generate all generate targets.
    generate-klone            > Generate klone shared Makefiles
    generate-base             > Generate base files in the repository

[shared] Build
    exe-publish               > Build the go source for release. This will build the source
                                for all release platforms and architectures. Additionally,
                                this will create a checksums file, sboms and sign the binaries.
    $(run_targets)            > Directly run the go source locally.
    $(oci_push_targets)       > Build and push OCI image.
                                If the tag already exists, this target will overwrite it.
                                If an identical image was already built before, we will add a new tag to it, but we will not sign it again.
                                Expected pushed images:
                                - :v1.2.3, @sha256:0000001
                                - :v1.2.3.sig, :sha256-0000001.sig
    $(oci_maybe_push_targets) > Run 'make oci-push-...' if tag does not already exist in registry.
    $(oci_load_targets)       > Build OCI image for the local architecture and load
                                it into the $(kind_cluster_name) kind cluster.
    $(oci_build_targets)      > Build the OCI image.
    $(build_targets)          > Build the go source locally for development/ testing
                                on the local platform.

Testing
    test-unit                 > Unit tests
    test-integration          > Integration tests
```