### PR TITLE
Helm "artifacthub.io/prerelease" annotation

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -53,6 +53,9 @@ $(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_d
 		echo "Chart name does not match the name in the helm_chart_name variable"; \
 		exit 1; \
 	fi
+	
+	$(YQ) '.annotations."artifacthub.io/prerelease" = "$(IS_PRERELEASE)"' \
+		--inplace $(helm_chart_source_dir_versioned)/Chart.yaml
 
 	mkdir -p $(dir $@)
 	$(HELM) package $(helm_chart_source_dir_versioned) \

--- a/modules/repository-base/base/Makefile
+++ b/modules/repository-base/base/Makefile
@@ -58,6 +58,7 @@ endif
 ##################################
 
 VERSION ?= $(shell git describe --tags --always --match='v*' --abbrev=14 --dirty)
+IS_PRERELEASE := $(shell git describe --tags --always --match='v*' --abbrev=0 | grep -q '-' && echo true || echo false)
 GITCOMMIT := $(shell git rev-parse HEAD)
 GITEPOCH := $(shell git show -s --format=%ct HEAD)
 


### PR DESCRIPTION
This PR adds a step to the Helm chart creation process that sets the "artifacthub.io/prerelease" annotation in the Chart.yaml file.
