### PR TITLE
Set empty 'shared_generate_targets' and 'shared_verify_targets_dirty' variables in the generate-verify module

### DIFF
--- a/modules/controller-gen/01_mod.mk
+++ b/modules/controller-gen/01_mod.mk
@@ -16,8 +16,6 @@
 # Check Inputs #
 ################
 
-shared_generate_targets ?= # empty
-
 ifndef go_header_file
 $(error go_header_file is not set)
 endif

--- a/modules/generate-verify/00_mod.mk
+++ b/modules/generate-verify/00_mod.mk
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Shared targets are set by other Makefile modules.
+shared_generate_targets ?=
+shared_verify_targets_dirty ?=
+
+# Extra targets are set by the Makefiles in the project.
 extra_generate_targets ?=
 extra_verify_targets ?=
 extra_verify_targets_dirty ?=

--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -16,8 +16,6 @@
 # Check Inputs #
 ################
 
-shared_generate_targets ?= # empty
-
 ifndef helm_chart_source_dir
 $(error helm_chart_source_dir is not set)
 endif


### PR DESCRIPTION
Simplifies the module and prevents warnings in case these variables have not been set.