### PR TITLE
BUGFIX: self-upgrade should also commit new files

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           git config --global user.name "jetstack-bot"
           git config --global user.email "jetstack-bot@users.noreply.github.com"
-          git commit -a -m "BOT: run 'make upgrade-klone' and 'make generate'" --signoff
+          git add -A && git commit -m "BOT: run 'make upgrade-klone' and 'make generate'" --signoff
           git push -f origin self-upgrade
 
       - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}


### PR DESCRIPTION
I noticed that in https://github.com/cert-manager/approver-policy/pull/345 a newly created file is missing from the PR.
This is due to a bug in the self-upgrade script.
This PR fixes that bug.