### PR TITLE
Small tweaks to the oci-images module

### DIFF
--- a/modules/oci-image/01_mod.mk
+++ b/modules/oci-image/01_mod.mk
@@ -93,7 +93,7 @@ $(run_targets): run-%: | $(NEEDS_GO)
 $(oci_build_targets): oci-build-%: | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS_YQ) $(bin_dir)/scratch/image
 	$(eval oci_layout_path := $(bin_dir)/scratch/image/oci-layout-$*.$(oci_$*_image_tag))
 	rm -rf $(CURDIR)/$(oci_layout_path)
-	
+
 	echo '{}' | \
 		$(YQ) '.defaultBaseImage = "$(oci_$*_base_image)"' | \
 		$(YQ) '.builds[0].id = "$*"' | \

--- a/modules/oci-image/01_mod.mk
+++ b/modules/oci-image/01_mod.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-oci_platforms := all
+oci_platforms := linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/modules/oci-image/01_mod.mk
+++ b/modules/oci-image/01_mod.mk
@@ -82,6 +82,7 @@ ARGS ?= # default empty
 ## Run a controller from your host.
 ## @category [shared] Build
 $(run_targets): run-%: | $(NEEDS_GO)
+	CGO_ENABLED=$(CGO_ENABLED) \
 	$(GO) run \
 		-ldflags '$(go_$*_ldflags)' \
 		$(go_$*_source_path) $(ARGS)


### PR DESCRIPTION
The most important here is limiting the platforms (I can split the other commits out if needed but they're so trivial it seemed worth including them).

## Releases

Looking at images for [approver-policy](https://quay.io/repository/jetstack/cert-manager-approver-policy?tab=tags&tag=latest) we supported arm64, amd64, armv6 and ppc64le when we released v0.11.0

v0.12.0-alpha.0 was released using makefile modules, and adds s390x. That alone is a fairly big commitment since we're adding another platform to support which we don't test (and likely won't test any time soon). For that reason alone I think it's worth limiting our builds to the previous platforms.

We do have some support for s390x elsewhere (cmctl releases) but I don't think we should expand other things to support it without a specific request.

## Local Builds

If I build locally the following are built:

```console
# csi-driver
$ make oci-build-manager
2024/01/17 09:50:22 Building cmd/main.go for linux/386
2024/01/17 09:50:23 Building cmd/main.go for linux/s390x
2024/01/17 09:50:25 Building cmd/main.go for linux/amd64
2024/01/17 09:50:26 Building cmd/main.go for linux/arm/v6
2024/01/17 09:50:27 Building cmd/main.go for linux/arm/v7
2024/01/17 09:50:28 Building cmd/main.go for linux/arm64
2024/01/17 09:50:30 Building cmd/main.go for linux/ppc64le
```

armv6 and 386 seem like crazy things to build - and they certainly won't be tested locally. I've confirmed that applying this PR will stop those platforms (and s390x) being built.

(NB: This command actually fails due a different bug which can be addressed in a separate PR)