### PR TITLE
Remove extra_*_targets variables

### DIFF
--- a/modules/generate-verify/00_mod.mk
+++ b/modules/generate-verify/00_mod.mk
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Shared targets are set by other Makefile modules.
 shared_generate_targets ?=
+shared_verify_targets ?=
 shared_verify_targets_dirty ?=
-
-# Extra targets are set by the Makefiles in the project.
-extra_generate_targets ?=
-extra_verify_targets ?=
-extra_verify_targets_dirty ?=

--- a/modules/generate-verify/02_mod.mk
+++ b/modules/generate-verify/02_mod.mk
@@ -15,7 +15,7 @@
 .PHONY: generate
 ## Generate all generate targets.
 ## @category [shared] Generate/ Verify
-generate: $(shared_generate_targets) $(extra_generate_targets)
+generate: $(shared_generate_targets)
 
 verify_script := $(dir $(lastword $(MAKEFILE_LIST)))/util/verify.sh
 
@@ -26,6 +26,6 @@ verify-%: FORCE
 .PHONY: verify
 ## Verify code and generate targets.
 ## @category [shared] Generate/ Verify
-verify: $(shared_generate_targets:%=verify-%) $(extra_generate_targets:%=verify-%) $(shared_verify_targets) $(extra_verify_targets)
+verify: $(shared_generate_targets:%=verify-%) $(shared_verify_targets)
 	@echo "The following targets create temporary files in the current directory, that is why they have to be run last:"
-	$(MAKE) noop $(shared_verify_targets_dirty) $(extra_verify_targets_dirty)
+	$(MAKE) noop $(shared_verify_targets_dirty)


### PR DESCRIPTION
In https://github.com/cert-manager/makefile-modules/pull/31, I tried to simplify these variables.
However, at this point I do not know why we have separate `extra_generate_targets` and `shared_generate_targets` variables.