### PR TITLE
Fix ko/ go weirdness

### DIFF
--- a/modules/executable/01_mod.mk
+++ b/modules/executable/01_mod.mk
@@ -34,15 +34,25 @@ $(call fatal_if_undefined,go_$1_ldflags)
 $(call fatal_if_undefined,go_$1_main_dir)
 $(call fatal_if_undefined,go_$1_mod_dir)
 
+ifneq ($(go_$1_main_dir:.%=.),.)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES start with ".")
+endif
 ifeq ($(go_$1_main_dir:%/=/),/)
 $$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with "/")
 endif
 ifeq ($(go_$1_main_dir:%.go=.go),.go)
 $$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with ".go")
 endif
-ifneq ($(go_$1_mod_dir:%/=/),/)
-$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory that ends with "/")
+ifneq ($(go_$1_mod_dir:\.%=\.),.)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES start with ".")
 endif
+ifeq ($(go_$1_mod_dir:%/=/),/)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_mod_dir:%.go=.go),.go)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+
 endef
 
 $(foreach build_name,$(all_exe_build_names),$(eval $(call check_variables,$(build_name))))

--- a/modules/executable/01_mod.mk
+++ b/modules/executable/01_mod.mk
@@ -22,6 +22,7 @@ ifndef build_names
 ifndef exe_build_names
 $(error build_names and exe_build_names are not set)
 endif
+build_names := # empty
 endif
 
 all_exe_build_names := $(sort $(build_names) $(exe_build_names))
@@ -30,7 +31,18 @@ fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not
 
 define check_variables
 $(call fatal_if_undefined,go_$1_ldflags)
-$(call fatal_if_undefined,go_$1_source_path)
+$(call fatal_if_undefined,go_$1_main_dir)
+$(call fatal_if_undefined,go_$1_mod_dir)
+
+ifeq ($(go_$1_main_dir:%/=/),/)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_main_dir:%.go=.go),.go)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+ifneq ($(go_$1_mod_dir:%/=/),/)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory that ends with "/")
+endif
 endef
 
 $(foreach build_name,$(all_exe_build_names),$(eval $(call check_variables,$(build_name))))
@@ -55,8 +67,10 @@ $(bin_dir)/bin:
 .PHONY: $(run_targets)
 ARGS ?= # default empty
 ## Directly run the go source locally.
+## Any Go workfile is ignored.
 ## @category [shared] Build
 $(run_targets): run-%: | $(NEEDS_GO)
+	GOWORK=off \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	GOEXPERIMENT=$(GOEXPERIMENT) \
 	$(GO) run \
@@ -64,9 +78,10 @@ $(run_targets): run-%: | $(NEEDS_GO)
 		$(go_$*_source_path) $(ARGS)
 
 ## Build the go source locally for development/ testing
-## on the local platform.
+## on the local platform. Any Go workfile is ignored.
 ## @category [shared] Build
 $(build_targets): $(bin_dir)/bin/%: FORCE | $(NEEDS_GO)
+	GOWORK=off \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	GOEXPERIMENT=$(GOEXPERIMENT) \
 	$(GO) build \
@@ -76,7 +91,8 @@ $(build_targets): $(bin_dir)/bin/%: FORCE | $(NEEDS_GO)
 
 define template_for_target
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .binary = "$(1)")' | \
-	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .main = "$(go_$(1)_source_path)")' | \
+	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .main = "$(go_$(1)_main_dir)")' | \
+	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .dir = "$(go_$(1)_mod_dir)")' | \
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .env[0] = "CGO_ENABLED={{.Env.CGO_ENABLED}}")' | \
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .env[1] = "GOEXPERIMENT={{.Env.GOEXPERIMENT}}")' | \
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .mod_timestamp = "{{.Env.SOURCE_DATE_EPOCH}}")' | \
@@ -106,6 +122,7 @@ ifeq ($(RELEASE_DRYRUN),true)
 	$(eval extra_args := $(extra_args) --skip=announce,publish,validate,sign)
 endif
 
+	GOWORK=off \
 	SOURCE_DATE_EPOCH=$(GITEPOCH) \
 	CGO_ENABLED=$(CGO_ENABLED) \
 	GOEXPERIMENT=$(GOEXPERIMENT) \

--- a/modules/oci-image/01_mod.mk
+++ b/modules/oci-image/01_mod.mk
@@ -35,7 +35,8 @@ fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not
 
 define check_variables
 $(call fatal_if_undefined,go_$1_ldflags)
-$(call fatal_if_undefined,go_$1_source_path)
+$(call fatal_if_undefined,go_$1_main_dir)
+$(call fatal_if_undefined,go_$1_mod_dir)
 $(call fatal_if_undefined,oci_$1_base_image_flavor)
 $(call fatal_if_undefined,oci_$1_image_name)
 $(call fatal_if_undefined,oci_$1_image_name_development)
@@ -48,6 +49,15 @@ else
     $$(error oci_$1_base_image_flavor has unknown value "$(oci_$1_base_image_flavor)")
 endif
 
+ifeq ($(go_$1_main_dir:%/=/),/)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_main_dir:%.go=.go),.go)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+ifneq ($(go_$1_mod_dir:%/=/),/)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory that ends with "/")
+endif
 endef
 
 $(foreach build_name,$(build_names),$(eval $(call check_variables,$(build_name))))
@@ -73,26 +83,36 @@ $(oci_build_targets): oci-build-%: | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS_YQ) $(bin_d
 	$(eval oci_layout_path := $(bin_dir)/scratch/image/oci-layout-$*.$(oci_$*_image_tag))
 	rm -rf $(CURDIR)/$(oci_layout_path)
 
+	@if [ ! -f "$(go_$*_mod_dir)go.mod" ]; then \
+		echo "ERROR: Specified directory "$(go_$*_mod_dir)" does not contain a go.mod file."; \
+		exit 1; \
+	fi
+
+	@if [ ! -f "$(go_$*_mod_dir)$(go_$*_main_dir)/main.go" ]; then \
+		echo "ERROR: Specified directory "$(go_$*_mod_dir)$(go_$*_main_dir)" does not contain a main.go file."; \
+		exit 1; \
+	fi
+
 	echo '{}' | \
 		$(YQ) '.defaultBaseImage = "$(oci_$*_base_image)"' | \
 		$(YQ) '.builds[0].id = "$*"' | \
-		$(YQ) '.builds[0].main = "$(go_$*_source_path)"' | \
-		$(YQ) '.builds[0].env[0] = "CGO_ENABLED={{.Env.CGO_ENABLED}}"' | \
-		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT={{.Env.GOEXPERIMENT}}"' | \
+		$(YQ) '.builds[0].dir = "$(go_$*_mod_dir)"' | \
+		$(YQ) '.builds[0].main = "$(go_$*_main_dir)"' | \
+		$(YQ) '.builds[0].env[0] = "CGO_ENABLED=$(CGO_ENABLED)"' | \
+		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT=$(GOEXPERIMENT)"' | \
 		$(YQ) '.builds[0].ldflags[0] = "-s"' | \
 		$(YQ) '.builds[0].ldflags[1] = "-w"' | \
 		$(YQ) '.builds[0].ldflags[2] = "{{.Env.LDFLAGS}}"' \
 		> $(CURDIR)/$(oci_layout_path).ko_config.yaml
 
+	GOWORK=off \
 	KO_DOCKER_REPO=$(oci_$*_image_name_development) \
 	KOCACHE=$(bin_dir)/scratch/image/ko_cache \
 	KO_CONFIG_PATH=$(CURDIR)/$(oci_layout_path).ko_config.yaml \
 	SOURCE_DATE_EPOCH=$(GITEPOCH) \
 	KO_GO_PATH=$(GO) \
 	LDFLAGS="$(go_$*_ldflags)" \
-	CGO_ENABLED=$(CGO_ENABLED) \
-	GOEXPERIMENT=$(GOEXPERIMENT) \
-	$(KO) build $(go_$*_source_path) \
+	$(KO) build $(go_$*_mod_dir)$(go_$*_main_dir) \
 		--platform=$(oci_platforms) \
 		--oci-layout-path=$(oci_layout_path) \
 		--sbom-dir=$(CURDIR)/$(oci_layout_path).sbom \
@@ -100,7 +120,7 @@ $(oci_build_targets): oci-build-%: | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS_YQ) $(bin_d
 		--push=false \
 		--bare
 
-	cd $(image_tool_dir) && $(GO) run . list-digests \
+	cd $(image_tool_dir) && GOWORK=off $(GO) run . list-digests \
 		$(CURDIR)/$(oci_layout_path) \
 		> $(CURDIR)/$(oci_layout_path).digests
 
@@ -146,5 +166,5 @@ $(oci_load_targets): oci_platforms := ""
 $(oci_load_targets): oci-load-%: oci-build-% | kind-cluster $(NEEDS_KIND)
 	$(eval oci_layout_path := $(bin_dir)/scratch/image/oci-layout-$*.$(oci_$*_image_tag))
 
-	cd $(image_tool_dir) && $(GO) run . convert-to-docker-tar $(CURDIR)/$(oci_layout_path) $(CURDIR)/$(oci_layout_path).docker.tar $(oci_$*_image_name_development):$(oci_$*_image_tag)
+	cd $(image_tool_dir) && GOWORK=off $(GO) run . convert-to-docker-tar $(CURDIR)/$(oci_layout_path) $(CURDIR)/$(oci_layout_path).docker.tar $(oci_$*_image_name_development):$(oci_$*_image_tag)
 	$(KIND) load image-archive --name $(kind_cluster_name) $(oci_layout_path).docker.tar

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -282,7 +282,7 @@ GO_DEPENDENCIES += helm-tool=github.com/cert-manager/helm-tool
 
 define go_dependency
 $$(bin_dir)/downloaded/tools/$1@$($(call UC,$1)_VERSION)_%: | $$(NEEDS_GO) $$(bin_dir)/downloaded/tools
-	GOBIN=$$(CURDIR)/$$(dir $$@) $$(GO) install $2@$($(call UC,$1)_VERSION)
+	GOWORK=off GOBIN=$$(CURDIR)/$$(dir $$@) $$(GO) install $2@$($(call UC,$1)_VERSION)
 	@mv $$(CURDIR)/$$(dir $$@)/$1 $$@
 endef
 


### PR DESCRIPTION
This PR does the following:
1. provides both the dir and main options to ko and gorelease
2. disabling Go workfiles
3. adds a lot of extra validation on the dir and main options

This fixes the following issues for me:
1. builds would not work for go submodules
2. ko was ignoring the config in the generated `ko_config.yaml`
3. the build would behave differently with or without a go.work file present