### PR TITLE
FIX: ko was using the wrong cache directory

### DIFF
--- a/modules/oci-image/01_mod.mk
+++ b/modules/oci-image/01_mod.mk
@@ -117,7 +117,7 @@ $(oci_build_targets): oci-build-%: | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS_YQ) $(bin_d
 
 	GOWORK=off \
 	KO_DOCKER_REPO=$(oci_$*_image_name_development) \
-	KOCACHE=$(bin_dir)/scratch/image/ko_cache \
+	KOCACHE=$(CURDIR)/$(bin_dir)/scratch/image/ko_cache \
 	KO_CONFIG_PATH=$(CURDIR)/$(oci_layout_path).ko_config.yaml \
 	SOURCE_DATE_EPOCH=$(GITEPOCH) \
 	KO_GO_PATH=$(GO) \


### PR DESCRIPTION
If `go_manager_mod_dir` is not `.`, the wrong cache directory is used (a directory relative to the `go_manager_mod_dir`.