### PR TITLE
Fix loading kind images on macOS

### DIFF
--- a/modules/oci-image/image_tool/main.go
+++ b/modules/oci-image/image_tool/main.go
@@ -107,7 +107,7 @@ func convertToDockerTar(path string, output string, imageName string) error {
 				return nil, err
 			}
 
-			if config.Platform().OS == runtime.GOOS && config.Platform().Architecture == runtime.GOARCH {
+			if config.Platform().Architecture == runtime.GOARCH {
 				matchingImages = append(matchingImages, obj)
 			}
 		case oci.SignedImageIndex:


### PR DESCRIPTION
This image is run outside containers, so `runtime.GOOS` is `darwin` on macOS and no image will ever be found.

The kind target environment on M1 is `linux/arm64`, and the target environment on Intel macs would be `linux/amd64` - no need for `GOOS`.