### PR TITLE
fix: defer dependency expansion of generate and verify targets

### DIFF
--- a/modules/generate-verify/02_mod.mk
+++ b/modules/generate-verify/02_mod.mk
@@ -15,7 +15,7 @@
 .PHONY: generate
 ## Generate all generate targets.
 ## @category [shared] Generate/ Verify
-generate: $(shared_generate_targets)
+generate: $$(shared_generate_targets)
 
 verify_script := $(dir $(lastword $(MAKEFILE_LIST)))/util/verify.sh
 
@@ -23,9 +23,11 @@ verify_script := $(dir $(lastword $(MAKEFILE_LIST)))/util/verify.sh
 verify-%: FORCE
 	$(verify_script) $(MAKE) -s $*
 
+verify_generated_targets = $(shared_generate_targets:%=verify-%)
+
 .PHONY: verify
 ## Verify code and generate targets.
 ## @category [shared] Generate/ Verify
-verify: $(shared_generate_targets:%=verify-%) $(shared_verify_targets)
+verify: $$(verify_generated_targets) $$(shared_verify_targets)
 	@echo "The following targets create temporary files in the current directory, that is why they have to be run last:"
 	$(MAKE) noop $(shared_verify_targets_dirty)

--- a/modules/repository-base/base/Makefile
+++ b/modules/repository-base/base/Makefile
@@ -29,6 +29,13 @@
 
 ##################################
 
+# Some modules build their dependencies from variables, we want these to be 
+# evalutated at the last possible moment. For this we use second expansion to 
+# re-evaluate the generate and verify targets a second time.
+#
+# See https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html
+.SECONDEXPANSION:
+
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -uo pipefail -c


### PR DESCRIPTION
If a module adds a variable to shared_generate_targets after the generate module has been parsed, it is not include in `make generate` or `make verify`. This change uses a second expansion to defer the evaluation of those dependencies to the end