### PR TITLE
fix: defer generate and verify expansion

### DIFF
--- a/modules/generate-verify/02_mod.mk
+++ b/modules/generate-verify/02_mod.mk
@@ -15,7 +15,7 @@
 .PHONY: generate
 ## Generate all generate targets.
 ## @category [shared] Generate/ Verify
-generate: $(shared_generate_targets)
+generate: $$(shared_generate_targets)
 
 verify_script := $(dir $(lastword $(MAKEFILE_LIST)))/util/verify.sh
 
@@ -23,9 +23,11 @@ verify_script := $(dir $(lastword $(MAKEFILE_LIST)))/util/verify.sh
 verify-%: FORCE
 	$(verify_script) $(MAKE) -s $*
 
+verify_generated_targets = $(shared_generate_targets:%=verify-%)
+
 .PHONY: verify
 ## Verify code and generate targets.
 ## @category [shared] Generate/ Verify
-verify: $(shared_generate_targets:%=verify-%) $(shared_verify_targets)
+verify: $$(verify_generated_targets) $$(shared_verify_targets)
 	@echo "The following targets create temporary files in the current directory, that is why they have to be run last:"
 	$(MAKE) noop $(shared_verify_targets_dirty)


### PR DESCRIPTION
This was originally introduced a couple of weeks ago, but was backed out while "SECONDEXPANSION" change required by this was rolled out.

Now that is out everywhere we can re-add this change. 

The main crux of this change is to use SECONDEXPANSION, a feature where target dependencies are evaluated twice, to ensure that some targets dependencies are resolved at the last possible moment and therefor can account for all variable changes.

The first two targets to use this are the `generate` and `verify` targets.