### PR TITLE
Add verify target for linting the values.yaml and template variables

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -98,6 +98,16 @@ generate-helm-schema: | $(NEEDS_HELM-TOOL) $(NEEDS_GOJQ)
 shared_generate_targets += generate-helm-schema
 endif
 
+ifdef helm_verify_values
+.PHONY: verify-helm-values
+## Verify Helm chart values using helm-tool.
+## @category [shared] Generate/ Verify
+verify-helm-values: | $(NEEDS_HELM-TOOL) $(NEEDS_GOJQ)
+	$(HELM-TOOL) lint -i $(helm_chart_source_dir)/values.yaml -d $(helm_chart_source_dir)/templates -e $(helm_chart_source_dir)/values.linter.exceptions
+
+shared_verify_targets += verify-helm-values
+endif
+
 .PHONY: verify-pod-security-standards
 ## Verify that the Helm chart complies with the pod security standards.
 ## @category [shared] Generate/ Verify

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -95,7 +95,7 @@ TOOLS += goreleaser=v1.23.0
 # https://pkg.go.dev/github.com/anchore/syft/cmd/syft?tab=versions
 TOOLS += syft=v0.100.0
 # https://github.com/cert-manager/helm-tool
-TOOLS += helm-tool=v0.3.0
+TOOLS += helm-tool=v0.4.1
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION=v0.29.1


### PR DESCRIPTION
Adds a target to lint the Helm values.yaml file.
This target can be enabled using the `helm_verify_values` variable.