### PR TITLE
Add 'make help' target expansion

### DIFF
--- a/modules/help/01_mod.mk
+++ b/modules/help/01_mod.mk
@@ -17,4 +17,6 @@ help_sh := $(dir $(lastword $(MAKEFILE_LIST)))/help.sh
 
 .PHONY: help
 help:
-	@MAKEFILE_LIST="$(MAKEFILE_LIST)" $(help_sh)
+	@MAKEFILE_LIST="$(MAKEFILE_LIST)" \
+		MAKE="$(MAKE)" \
+		$(help_sh)


### PR DESCRIPTION
Fixes https://github.com/cert-manager/istio-csr/issues/277

Before:
```
$ make
Usage: make [target1] [target2] ...

[shared] Tools
    which-go                      > Print the version and path of go which will be used for building and
                                    testing in Makefile commands. Vendored go will have a path in ./bin
    vendor-go                     > By default, this Makefile uses the system's Go. You can use a "vendored"
                                    version of Go that will get downloaded by running this command once. To
                                    disable vendoring, run "make unvendor-go". When vendoring is enabled,
                                    you will want to set the following:
                                    
                                    export PATH="$PWD/$(bin_dir)/tools:$PATH"
                                    export GOROOT="$PWD/$(bin_dir)/tools/goroot"
    tools                         > Download and setup all tools
    clean                         > Clean all temporary files

[shared] Self-upgrade
    upgrade-klone                 > Upgrade klone Makefile modules to latest version

[shared] Release
    release                       > Publish all release artifacts (image + helm chart)

[shared] Kind cluster
    kind-logs                     > Get the Kind cluster
    kind-cluster                  > Create Kind cluster and wait for nodes to be ready
    kind-cluster-clean            > Delete the Kind cluster
    images-preload                > Preload images.

[shared] Helm Chart
    helm-chart                    > Create a helm chart

[shared] Generate/ Verify
    verify                        > Verify code and generate targets.
    verify-pod-security-standards > Verify that the Helm chart complies with the pod security standards.
    verify-helm-values            > Verify Helm chart values using helm-tool.
    verify-helm-lint              > Verify that the Helm chart is linted.
    verify-generate-api-docs      > Verify that the API docs are up to date.
    verify-boilerplate            > Verify that all files have the correct boilerplate.
    generate                      > Generate all generate targets.
    generate-klone                > Generate klone shared Makefiles
    generate-helm-schema          > Generate Helm chart schema.
    generate-helm-docs            > Generate Helm chart documentation.
    generate-helm-docs            > Generate Helm chart documentation.
    generate-deepcopy             > Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
    generate-crds                 > Generate CRD manifests.
    generate-base                 > Generate base files in the repository
    generate-api-docs             > Generate API docs for the API types.

[shared] Deployment
    uninstall                     > Uninstall controller helm chart from the current active K8S cluster.
    template                      > Template the helm chart.
    install                       > Install controller helm chart on the current active K8S cluster.

[shared] Build
    $(oci_push_targets)           > Build and push OCI image.
                                    If the tag already exists, this target will overwrite it.
                                    If an identical image was already built before, we will add a new tag to it, but we will not sign it again.
                                    Expected pushed images:
                                    - :v1.2.3, @sha256:0000001
                                    - :v1.2.3.sig, :sha256-0000001.sig
    $(oci_maybe_push_targets)     > Run 'make oci-push-...' if tag does not already exist in registry.
    $(oci_load_targets)           > Build OCI image for the local architecture and load
                                    it into the $(kind_cluster_name) kind cluster.
    $(oci_build_targets)          > Build the OCI image.
    $(docker_tarball_targets)     > Build Docker tarball image for the local architecture

Testing
    test-unit                     > Unit tests
    test-smoke                    > Smoke end-to-end tests

Generate/ Verify
    generate-protos               > Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
```

After:
```
$ make
Usage: make [target1] [target2] ...

[shared] Tools
    which-go                      > Print the version and path of go which will be used for building and
                                    testing in Makefile commands. Vendored go will have a path in ./bin
    vendor-go                     > By default, this Makefile uses the system's Go. You can use a "vendored"
                                    version of Go that will get downloaded by running this command once. To
                                    disable vendoring, run "make unvendor-go". When vendoring is enabled,
                                    you will want to set the following:
                                    
                                    export PATH="$PWD/$(bin_dir)/tools:$PATH"
                                    export GOROOT="$PWD/$(bin_dir)/tools/goroot"
    tools                         > Download and setup all tools
    clean                         > Clean all temporary files

[shared] Self-upgrade
    upgrade-klone                 > Upgrade klone Makefile modules to latest version

[shared] Release
    release                       > Publish all release artifacts (image + helm chart)

[shared] Kind cluster
    kind-logs                     > Get the Kind cluster
    kind-cluster                  > Create Kind cluster and wait for nodes to be ready
    kind-cluster-clean            > Delete the Kind cluster
    images-preload                > Preload images.

[shared] Helm Chart
    helm-chart                    > Create a helm chart

[shared] Generate/ Verify
    verify                        > Verify code and generate targets.
    verify-pod-security-standards > Verify that the Helm chart complies with the pod security standards.
    verify-helm-values            > Verify Helm chart values using helm-tool.
    verify-helm-lint              > Verify that the Helm chart is linted.
    verify-generate-api-docs      > Verify that the API docs are up to date.
    verify-boilerplate            > Verify that all files have the correct boilerplate.
    generate                      > Generate all generate targets.
    generate-klone                > Generate klone shared Makefiles
    generate-helm-schema          > Generate Helm chart schema.
    generate-helm-docs            > Generate Helm chart documentation.
    generate-helm-docs            > Generate Helm chart documentation.
    generate-deepcopy             > Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
    generate-crds                 > Generate CRD manifests.
    generate-base                 > Generate base files in the repository
    generate-api-docs             > Generate API docs for the API types.

[shared] Deployment
    uninstall                     > Uninstall controller helm chart from the current active K8S cluster.
    template                      > Template the helm chart.
    install                       > Install controller helm chart on the current active K8S cluster.

[shared] Build
    oci-push-manager              > Build and push OCI image.
                                    If the tag already exists, this target will overwrite it.
                                    If an identical image was already built before, we will add a new tag to it, but we will not sign it again.
                                    Expected pushed images:
                                    - :v1.2.3, @sha256:0000001
                                    - :v1.2.3.sig, :sha256-0000001.sig
    oci-maybe-push-manager        > Run 'make oci-push-...' if tag does not already exist in registry.
    oci-load-manager              > Build OCI image for the local architecture and load
                                    it into the $(kind_cluster_name) kind cluster.
    oci-build-manager             > Build the OCI image.
    docker-tarball-manager        > Build Docker tarball image for the local architecture

Testing
    test-unit                     > Unit tests
    test-smoke                    > Smoke end-to-end tests

Generate/ Verify
    generate-protos               > Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
```