### PR TITLE
Don't error in case $(...) target is not found

### DIFF
--- a/modules/help/help.sh
+++ b/modules/help/help.sh
@@ -93,8 +93,10 @@ IFS=$'\n'; for line in $extracted_lines; do
 
     # replace any $(...) with the actual value
     if [[ $target =~ \$\((.*)\) ]]; then
-        target=$(echo -e "$extracted_expansions" | grep "<start-target>${BASH_REMATCH[1]}<end-target>")
-        target=$([[ $target =~ \<start-expansion\>(.*)\<end-expansion\> ]] && echo -e "${BASH_REMATCH[1]}")
+        new_target=$(echo -e "$extracted_expansions" | grep "<start-target>${BASH_REMATCH[1]}<end-target>" || true)
+        if [[ -n "$new_target" ]]; then
+            target=$([[ $new_target =~ \<start-expansion\>(.*)\<end-expansion\> ]] && echo -e "${BASH_REMATCH[1]}")
+        fi
     fi
 
     # Print the target and its multiline comment


### PR DESCRIPTION
We replace variable targets with their value.
However, when we have a variable target that has not value defined, the script fails.
For eg. cert-manager's `$(E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_FILE)` this causes issues.
This PR fixes this issue by keeping the $(...) expression if the variable is not found.