### PR TITLE
Add a make verify-govulncheck target

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ When developing a new module, put your targets in `01_mod.mk`.
 This is to ensure that the targets for downloading tool dependencies such as
 `NEEDS_XYZ` are included first and can be resolved.
 
+To test changes that you make in *this* repository:
+1. Open a branch in a *target repository* that consumes the new or changed module. E.g. approver-policy.
+2. Update the `klone.yaml` file in the target repository with a reference to the branch and commit containing the changes in *this* repository.
+3. Run `make upgrade-klone` in the target repository, to pull in your changes.
+4. Test the new or changed `make` target in the target repository.
+5. Fix any problems by pushing changes to your branch in *this* repository.
+6. Go to step 3 to pull latest changes into the target repository and then retest.
+
 ### Upgrading the tools in the tools module
 
 1. bump the versions in the modules/tools/00_mod.mk file

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The order in which the makefiles are includes is as follows (see [Makefile](./mo
 -include make/_shared/*/02_mod.mk
 ```
 
+When developing a new module, put your targets in `01_mod.mk`.
+This is to ensure that the targets for downloading tool dependencies such as
+`NEEDS_XYZ` are included first and can be resolved.
+
 ### Upgrading the tools in the tools module
 
 1. bump the versions in the modules/tools/00_mod.mk file

--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -1,0 +1,41 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifndef bin_dir
+$(error bin_dir is not set)
+endif
+
+.PHONY: verify-govulncheck
+## Verify all Go modules for vulnerabilities using govulncheck
+## @category [shared] Generate/ Verify
+#
+# Runs `govulncheck` on all Go modules related to the project.
+# Ignores Go modules among the temporary build artifacts in _bin, to avoid
+# scanning the code of the vendored Go, after running make vendor-go.
+# Ignores Go modules in make/_shared, because those will be checked in centrally
+# in the makefile_modules repository.
+#
+# `verify-govulncheck` not added to the `shared_verify_targets` variable and is
+# not run by `make verify`, because `make verify` is run for each PR, and we do
+# not want new vulnerabilities in existing code to block the merging of PRs.
+# Instead `make verify-govulnecheck` is intended to be run periodically by a CI job.
+verify-govulncheck: | $(NEEDS_GOVULNCHECK)
+	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) -printf '%h\n' \
+		| while read d; do \
+				echo "Running 'GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(bin_dir)/tools/govulncheck ./...' in directory '$${d}'"; \
+				pushd "$${d}" >/dev/null; \
+				GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(GOVULNCHECK) ./... || exit; \
+				popd >/dev/null; \
+				echo ""; \
+			done

--- a/modules/go/README.md
+++ b/modules/go/README.md
@@ -1,0 +1,3 @@
+# README
+
+A module for various Go static checks.

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -110,6 +110,8 @@ TOOLS += cmctl=2f75014a7c360c319f8c7c8afe8e9ce33fe26dca
 TOOLS += cmrel=fa10147dadc8c36718b7b08aed6d8c6418eb2
 # https://github.com/golangci/golangci-lint/releases
 TOOLS += golangci-lint=v1.55.2
+# https://pkg.go.dev/golang.org/x/vuln?tab=versions
+TOOLS += govulncheck=v1.0.4
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION=v0.29.1
@@ -308,6 +310,7 @@ GO_DEPENDENCIES += helm-tool=github.com/cert-manager/helm-tool
 GO_DEPENDENCIES += cmctl=github.com/cert-manager/cmctl/v2
 GO_DEPENDENCIES += cmrel=github.com/cert-manager/release/cmd/cmrel
 GO_DEPENDENCIES += golangci-lint=github.com/golangci/golangci-lint/cmd/golangci-lint
+GO_DEPENDENCIES += govulncheck=golang.org/x/vuln/cmd/govulncheck
 
 #################
 # go build tags #


### PR DESCRIPTION
Added a new module called `go` with a `make verify-govulncheck` target which can be executed manually or periodically in each target repository.
When run periodically from a GitHub Action or from prow, this will allow us to more easily see when a project has vulnerabilities.

## Testing

In https://github.com/cert-manager/approver-policy/pull/404 I've updated the `klone.yaml` file and pulled in this new target.
Here are examples of the output:

* Help 

```sh
$ make
...
[shared] Generate/ Verify
    verify                        > Verify code and generate targets.
    verify-pod-security-standards > Verify that the Helm chart complies with the pod security standards.
    verify-helm-values            > Verify Helm chart values using helm-tool.
    verify-helm-lint              > Verify that the Helm chart is linted.
    verify-govulncheck            > Verify all Go modules for vulnerabilities using govulncheck
    verify-generate-api-docs      > Verify that the API docs are up to date.
    verify-boilerplate            > Verify that all files have the correct boilerplate.
```

* Using latest Go 1.21, which has no vulnerabilities
```sh
$ make verify-govulncheck
Running 'GOTOOLCHAIN=go1.21.8 _bin/tools/govulncheck ./...' in directory '.'
Scanning your code and 1172 packages across 104 dependent modules for known vulnerabilities...

No vulnerabilities found.
```

* Using previous version of Go 1.21 which has known vulnerabilities.

```sh
$ make verify-govulncheck
Running 'GOTOOLCHAIN=go1.21.7 _bin/tools/govulncheck ./...' in directory '.'
Scanning your code and 1172 packages across 104 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2610
    Errors returned from JSON marshaling may break template escaping in
    html/template
  More info: https://pkg.go.dev/vuln/GO-2024-2610
  Standard library
    Found in: html/template@go1.21.7
    Fixed in: html/template@go1.21.8
    Example traces found:
      #1: test/env/env.go:73:24: env.RunControlPlane calls envtest.Environment.Start, which eventually calls template.Template.Execute
      #2: test/env/env.go:90:63: env.RunControlPlane calls webhook.StartWebhookServer, which eventually calls template.Template.ExecuteTemplate

Vulnerability #2: GO-2024-2609
    Comments in display names are incorrectly handled in net/mail
  More info: https://pkg.go.dev/vuln/GO-2024-2609
  Standard library
    Found in: net/mail@go1.21.7
    Fixed in: net/mail@go1.21.8
    Example traces found:
      #1: test/env/env.go:90:63: env.RunControlPlane calls webhook.StartWebhookServer, which eventually calls mail.ParseAddress

Vulnerability #3: GO-2024-2600
    Incorrect forwarding of sensitive headers and cookies on HTTP redirect in
    net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2600
  Standard library
    Found in: net/http@go1.21.7
    Fixed in: net/http@go1.21.8
    Example traces found:
      #1: pkg/internal/controllers/certificaterequests.go:162:36: controllers.certificaterequests.Reconcile calls client.subResourceClient.Patch, which eventually calls http.Client.Do
      #2: test/env/env.go:73:24: env.RunControlPlane calls envtest.Environment.Start, which eventually calls http.Client.Get

Vulnerability #4: GO-2024-2599
    Memory exhaustion in multipart form parsing in net/textproto and net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2599
  Standard library
    Found in: net/textproto@go1.21.7
    Fixed in: net/textproto@go1.21.8
    Example traces found:
      #1: test/env/env.go:90:63: env.RunControlPlane calls webhook.StartWebhookServer, which eventually calls textproto.Reader.ReadLine
      #2: pkg/cmd/cmd.go:35:14: cmd.ExecutePolicyApprover calls fmt.Fprintf, which eventually calls textproto.Reader.ReadMIMEHeader

Vulnerability #5: GO-2024-2598
    Verify panics on certificates with an unknown public key algorithm in
    crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2024-2598
  Standard library
    Found in: crypto/x509@go1.21.7
    Fixed in: crypto/x509@go1.21.8
    Example traces found:
      #1: pkg/cmd/cmd.go:35:14: cmd.ExecutePolicyApprover calls fmt.Fprintf, which eventually calls x509.Certificate.Verify

Your code is affected by 5 vulnerabilities from the Go standard library.
This scan found no other vulnerabilities in packages you import or modules you
require.
Use '-show verbose' for more details.
make: *** [make/_shared/go/01_mod.mk:34: verify-govulncheck] Error 3
```

```sh
$ echo $?
2
```