### PR TITLE
Add golangci-lint linting

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -1,0 +1,75 @@
+linters:
+  # Explicitly define all enabled linters
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - decorder
+    - dogsled
+    - dupword
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - execinquery
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gocritic
+    - gofmt
+    - goheader
+    - goimports
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - gosmopolitan
+    - govet
+    - grouper
+    - importas
+    - ineffassign
+    - interfacebloat
+    - loggercheck
+    - makezero
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nilerr
+    - nilnil
+    - noctx
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - promlinter
+    - protogetter
+    - reassign
+    - sloglint
+    - staticcheck
+    - tagalign
+    - tenv
+    - testableexamples
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - wastedassign
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix({{REPO-NAME}}) # Custom section: groups all imports with the specified Prefix.
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -109,7 +109,7 @@ TOOLS += cmctl=2f75014a7c360c319f8c7c8afe8e9ce33fe26dca
 # https://pkg.go.dev/github.com/cert-manager/release/cmd/cmrel?tab=versions
 TOOLS += cmrel=fa10147dadc8c36718b7b08aed6d8c6418eb2
 # https://github.com/golangci/golangci-lint/releases
-TOOLS += golangci-lint=v1.55.2
+TOOLS += golangci-lint=v1.57.1
 # https://pkg.go.dev/golang.org/x/vuln?tab=versions
 TOOLS += govulncheck=v1.0.4
 


### PR DESCRIPTION
Adds golangci-lint with most linters enabled (I used `golangci-lint linters` to enable them and check whether their output is useful).
We can disable the warnings in each repo by using the following:
```yaml
issues:
  exclude-rules:
    - linters:
        - errcheck
        - staticcheck
        - gosimple
        - contextcheck
        - promlinter
        - prealloc
        - containedctx
        - gci
        - errorlint
        - gosec
        - unparam
        - gocritic
        - gofmt
      text: ".*"
```