### PR TITLE
Remove unuseful linters and increase golangci-lint timeout

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -6,7 +6,6 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
-    - containedctx
     - contextcheck
     - decorder
     - dogsled
@@ -15,7 +14,6 @@ linters:
     - errcheck
     - errchkjson
     - errname
-    - errorlint
     - execinquery
     - exhaustive
     - exportloopref
@@ -27,7 +25,6 @@ linters:
     - gocritic
     - gofmt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -49,7 +46,6 @@ linters:
     - nilnil
     - noctx
     - nosprintfhostport
-    - prealloc
     - predeclared
     - promlinter
     - protogetter

--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -83,7 +83,7 @@ verify-golangci-lint: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/scratch
 		| while read d; do \
 				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config)' in directory '$${d}'"; \
 				pushd "$${d}" >/dev/null; \
-				$(GOLANGCI-LINT) run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) || exit; \
+				$(GOLANGCI-LINT) run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) --timeout 4m || exit; \
 				popd >/dev/null; \
 				echo ""; \
 			done


### PR DESCRIPTION
The `containedctx`, `errorlint` and `prealloc` linters give too many false-positives. In the future, we could re-add these linters, but I do not think they are useful right now.
I also disabled the `goimports` linter which overlaps with `gci`.

Lastly, this PR also increases the timeout for golangci-lint, which should prevent CI from failing due to timeout (eg. when there is no golangci-lint cache).