### PR TITLE
feat: update yq, add operator-sdk and github-cli

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -51,7 +51,7 @@ TOOLS += azwi=v1.2.0
 # https://github.com/kyverno/kyverno/releases
 TOOLS += kyverno=v1.11.3
 # https://github.com/mikefarah/yq/releases
-TOOLS += yq=v4.40.5
+TOOLS += yq=v4.43.1
 # https://github.com/ko-build/ko/releases
 TOOLS += ko=0.15.1
 # https://github.com/protocolbuffers/protobuf/releases
@@ -112,6 +112,10 @@ TOOLS += cmrel=fa10147dadc8c36718b7b08aed6d8c6418eb2
 TOOLS += golangci-lint=v1.57.1
 # https://pkg.go.dev/golang.org/x/vuln?tab=versions
 TOOLS += govulncheck=v1.0.4
+# https://pkg.go.dev/github.com/operator-framework/operator-sdk/cmd/operator-sdk?tab=versions
+TOOLS += operator-sdk=v1.34.1
+# https://pkg.go.dev/github.com/cli/cli/v2?tab=versions
+TOOLS += gh=v2.47.0
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION=v0.29.1
@@ -311,6 +315,8 @@ GO_DEPENDENCIES += cmctl=github.com/cert-manager/cmctl/v2
 GO_DEPENDENCIES += cmrel=github.com/cert-manager/release/cmd/cmrel
 GO_DEPENDENCIES += golangci-lint=github.com/golangci/golangci-lint/cmd/golangci-lint
 GO_DEPENDENCIES += govulncheck=golang.org/x/vuln/cmd/govulncheck
+GO_DEPENDENCIES += operator-sdk=github.com/operator-framework/operator-sdk/cmd/operator-sdk
+GO_DEPENDENCIES += gh=github.com/cli/cli/v2/cmd/gh
 
 #################
 # go build tags #
@@ -458,10 +464,10 @@ $(bin_dir)/downloaded/tools/kyverno@$(KYVERNO_VERSION)_%: | $(bin_dir)/downloade
 # yq #
 ######
 
-YQ_linux_amd64_SHA256SUM=0d6aaf1cf44a8d18fbc7ed0ef14f735a8df8d2e314c4cc0f0242d35c0a440c95
-YQ_linux_arm64_SHA256SUM=9431f0fa39a0af03a152d7fe19a86e42e9ff28d503ed4a70598f9261ec944a97
-YQ_darwin_amd64_SHA256SUM=7f88b959c3fd2755e77dbf5bd92780dc3626c1c00ac45d5b5134f04189a142dc
-YQ_darwin_arm64_SHA256SUM=1ef0022ed6d0769d19e2d391dd731162034b0e0ba2c9b53dda039d16cec1c26a
+YQ_linux_amd64_SHA256SUM=cfbbb9ba72c9402ef4ab9d8f843439693dfb380927921740e51706d90869c7e1
+YQ_linux_arm64_SHA256SUM=a8186efb079673293289f8c31ee252b0d533c7bb8b1ada6a778ddd5ec0f325b6
+YQ_darwin_amd64_SHA256SUM=fdc42b132ac460037f4f0f48caea82138772c651d91cfbb735210075ddfdbaed
+YQ_darwin_arm64_SHA256SUM=9f1063d910698834cb9176593aa288471898031929138d226c2c2de9f262f8e5
 
 $(bin_dir)/downloaded/tools/yq@$(YQ_VERSION)_%: | $(bin_dir)/downloaded/tools
 	$(CURL) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$* -o $@


### PR DESCRIPTION
This updates YQ to the newest version, addin the string interpolation feature.

It also adds the operator-sdk and github-cli tools that will be required for publishing OLM bundles through automation.