### PR TITLE
Replace tab with spaces in license header

### DIFF
--- a/modules/oci-build/image_tool/append_layers.go
+++ b/modules/oci-build/image_tool/append_layers.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
In https://github.com/cert-manager/makefile-modules/pull/108, one file contained a tab in the license header instead of a space. This causes the boilersuit tool to fail. This PR fixes the issue by replacing the tab with spaces.