### PR TITLE
Bump to go 1.22

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -140,7 +140,7 @@ ADDITIONAL_TOOLS ?=
 TOOLS += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-VENDORED_GO_VERSION := 1.21.9
+VENDORED_GO_VERSION := 1.22.2
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version


### PR DESCRIPTION
K8S 1.30 requires go1.22 and we're starting to see failures relating to that when bumping dependencies. See https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_approver-policy/424/pull-cert-manager-approver-policy-test/1782418309480714240 for an example:

> go: k8s.io/apimachinery@v0.30.0 requires go >= 1.22.0 (running go 1.21.9)

There doesn't seem to be any reason to hold back on upgrading now.