### PR TITLE
feat: add ability to rewrite image name before pushing

### DIFF
--- a/modules/oci-publish/00_mod.mk
+++ b/modules/oci-publish/00_mod.mk
@@ -1,0 +1,44 @@
+# Push names is equivilent to build_names, additional names can be added for 
+# pushing images that are not build with the oci-build module
+push_names ?=
+push_names += $(build_names)
+
+# Sometimes we need to push to one registry, but pull from another. This allows
+# that.
+#
+# The lines should be in the format a=b
+#
+# The value on the left is the domain you include in your oci_<name>_image_name
+# variable, the one on the right is the domain that is actually pushed to.
+#
+# For example, if we set up a vanity domain for the current quay:
+# 
+#   oci_controller_image_name = registry.cert-manager.io/cert-manager-controller` 
+#   image_registry_rewrite += registry.cert-manager.io=quay.io/jetstack
+#
+# This would push to quay.io/jetstack/cert-manager-controller.
+#
+# The general idea is oci_<name>_image_name contains the final image name, after replication, after vanity domains etc.
+
+image_registry_rewrite ?= 
+
+# Utilities for extracting the key and value from a foo=bar style line
+kv_key = $(word 1,$(subst =, ,$1))
+kv_value = $(word 2,$(subst =, ,$1))
+
+# Apply the image_registry_rewrite rules, if no rules match an image then the 
+# image name is not changed. Any rules that match will be applied.
+#
+# For example, if there was a rule vanity-domain.com=real-registry.com/foo
+# then any references to vanity-domain.com/image would be rewritten to 
+# real-registry.com/foo/image
+image_registry_rewrite_rules_for_image = $(strip $(sort $(foreach rule,$(image_registry_rewrite),$(if $(findstring $(call kv_key,$(rule)),$1),$(rule)))))
+apply_image_registry_rewrite_rules_to_image = $(if $(call image_registry_rewrite_rules_for_image,$1),\
+	$(foreach rule,$(call image_registry_rewrite_rules_for_image,$1),$(subst $(call kv_key,$(rule)),$(call kv_value,$(rule)),$1)),\
+	$1)
+apply_image_registry_rewrite_rules = $(foreach image_name,$1,$(call apply_image_registry_rewrite_rules_to_image,$(image_name)))
+
+# This is a helper function to return the image names for a given build_name.
+# It will apply all rewrite rules to the image names
+oci_image_names_for = $(call apply_image_registry_rewrite_rules,$(oci_$1_image_name))
+oci_image_tag_for = $(oci_$1_image_tag)

--- a/modules/oci-publish/01_mod.mk
+++ b/modules/oci-publish/01_mod.mk
@@ -24,7 +24,7 @@ current_makefile_directory = $(dir $(current_makefile))
 
 # Validate globals that are required
 $(call fatal_if_undefined,bin_dir)
-$(call fatal_if_undefined,build_names)
+$(call fatal_if_undefined,push_names)
 
 # Set default config values
 RELEASE_DRYRUN ?= false
@@ -32,7 +32,7 @@ CRANE_FLAGS ?= # empty by default
 COSIGN_FLAGS ?= # empty by default
 OCI_SIGN_ON_PUSH ?= true
 
-# Default variables per build_names entry
+# Default variables per push_names entry
 #
 # $1 - build_name
 define default_per_build_variables
@@ -42,9 +42,9 @@ cosign_flags_$1 ?= $(COSIGN_FLAGS)
 oci_sign_on_push_$1 ?= $(OCI_SIGN_ON_PUSH)
 endef
 
-$(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(build_name))))
+$(foreach build_name,$(push_names),$(eval $(call default_per_build_variables,$(build_name))))
 
-# Validate variables per build_names entry
+# Validate variables per push_names entry
 #
 # $1 - build_name
 define check_per_build_variables
@@ -54,18 +54,18 @@ $(call fatal_if_undefined,oci_$1_image_name)
 $(call fatal_if_undefined,oci_$1_image_tag)
 endef
 
-$(foreach build_name,$(build_names),$(eval $(call check_per_build_variables,$(build_name))))
+$(foreach build_name,$(push_names),$(eval $(call check_per_build_variables,$(build_name))))
 
 # Create variables holding targets
 #
-# We create the following targets for each $(build_names)
+# We create the following targets for each $(push_names)
 # - oci-build-$(build_name) = build the oci directory
 # - oci-load-$(build_name) = load the image into docker using the oci_$(build_name)_image_name_development variable
 # - docker-tarball-$(build_name) = build a "docker load" compatible tarball of the image
 # - ko-config-$(build_name) = generate "ko" config for a given build
-oci_push_targets := $(build_names:%=oci-push-%)
-oci_sign_targets := $(build_names:%=oci-sign-%)
-oci_maybe_push_targets := $(build_names:%=oci-maybe-push-%)
+oci_push_targets := $(push_names:%=oci-push-%)
+oci_sign_targets := $(push_names:%=oci-sign-%)
+oci_maybe_push_targets := $(push_names:%=oci-maybe-push-%)
 
 # Define push target 
 # $1 - build_name
@@ -73,13 +73,13 @@ oci_maybe_push_targets := $(build_names:%=oci-maybe-push-%)
 define oci_push_target
 .PHONY: $(call sanitize_target,oci-push-$2)
 $(call sanitize_target,oci-push-$2): oci-build-$1 | $(NEEDS_CRANE)
-	$$(CRANE) $(crane_flags_$1) push "$(oci_layout_path_$1)" "$2:$(oci_$1_image_tag)"
+	$$(CRANE) $(crane_flags_$1) push "$(oci_layout_path_$1)" "$2:$(call oci_image_tag_for,$1)"
 	$(if $(filter true,$(oci_sign_on_push_$1)),$(MAKE) $(call sanitize_target,oci-sign-$2))
 
 .PHONY: $(call sanitize_target,oci-maybe-push-$2)
 $(call sanitize_target,oci-maybe-push-$2): oci-build-$1 | $(NEEDS_CRANE)
-	$$(CRANE) $(crane_flags_$1) manifest $2:$(oci_$1_image_tag) > /dev/null 2>&1 || (\
-		$$(CRANE) $(crane_flags_$1) push "$(oci_layout_path_$1)" "$2:$(oci_$1_image_tag)" && \
+	$$(CRANE) $(crane_flags_$1) manifest $2:$(call oci_image_tag_for,$1) > /dev/null 2>&1 || (\
+		$$(CRANE) $(crane_flags_$1) push "$(oci_layout_path_$1)" "$2:$(call oci_image_tag_for,$1)" && \
 		$(if $(filter true,$(oci_sign_on_push_$1)),$(MAKE) $(call sanitize_target,oci-sign-$2)) \
 	)
 
@@ -88,7 +88,7 @@ oci-maybe-push-$1: $(call sanitize_target,oci-maybe-push-$2)
 endef
 
 oci_push_target_per_image = $(foreach image_name,$2,$(eval $(call oci_push_target,$1,$(image_name))))
-$(foreach build_name,$(build_names),$(eval $(call oci_push_target_per_image,$(build_name),$(oci_$(build_name)_image_name))))
+$(foreach build_name,$(push_names),$(eval $(call oci_push_target_per_image,$(build_name),$(oci_$(build_name)_image_name))))
 
 .PHONY: $(oci_push_targets)
 ## Build and push OCI image.
@@ -118,7 +118,7 @@ oci-sign-$1: $(call sanitize_target,oci-sign-$2)
 endef
 
 oci_sign_target_per_image = $(foreach image_name,$2,$(eval $(call oci_sign_target,$1,$(image_name))))
-$(foreach build_name,$(build_names),$(eval $(call oci_sign_target_per_image,$(build_name),$(oci_$(build_name)_image_name))))
+$(foreach build_name,$(push_names),$(eval $(call oci_sign_target_per_image,$(build_name),$(call oci_image_names_for,$(build_name)))))
 
 .PHONY: $(oci_sign_targets)
 ## Sign an OCI image.


### PR DESCRIPTION
There are two main changes:

- Previously we used `build_names` as a source for push targets, by using a different variable `push_names` we can create push targets for things that are not built with `oci-build` (which just builds golang containers)
- Allows specifying `image_registry_rewrite` rules in the format `vanity-domain.com=domain-we-push-to.com`. This allows us to know the final image names, as well as still be able to push to the correct registry.