### PR TITLE
fix: make verify fails due to characters in generate target

### DIFF
--- a/modules/licenses/00_mod.mk
+++ b/modules/licenses/00_mod.mk
@@ -24,7 +24,7 @@ $(generate_go_licenses_targets): | $(NEEDS_GO-LICENSES)
 ## Generate licenses for the golang dependencies
 ## @category [shared] Generate/Verify
 generate-go-licences: $(generate_go_licenses_targets)
-shared_generate_targets += $(generate_go_licenses_targets)
+shared_generate_targets += generate-go-licences
 
 # Target to generate image layer containing license information
 .PHONY: oci-license-layer-%


### PR DESCRIPTION
Previously the generate target was a path, since the verify target prefixes this the new verify target name was invalid. This fixes that