### PR TITLE
Bump cmrel version to latest commit

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -114,7 +114,7 @@ TOOLS += helm-tool=v0.4.2
 # https://github.com/cert-manager/cmctl
 TOOLS += cmctl=2f75014a7c360c319f8c7c8afe8e9ce33fe26dca
 # https://pkg.go.dev/github.com/cert-manager/release/cmd/cmrel?tab=versions
-TOOLS += cmrel=fa10147dadc8c36718b7b08aed6d8c6418eb2
+TOOLS += cmrel=84daedb44d61d25582e22eca48352012e899d1b2
 # https://github.com/golangci/golangci-lint/releases
 TOOLS += golangci-lint=v1.57.1
 # https://pkg.go.dev/golang.org/x/vuln?tab=versions


### PR DESCRIPTION
I am trying to upgrade controller-runtime to the latest release in https://github.com/cert-manager/cert-manager/pull/6967, but I am struggling to get the CI green. It seems like `go mod tidy` with the updated dependencies sets the Go requirement in `go.mod` to `1.22.2`. I am hoping that https://github.com/cert-manager/release/pull/131 will fix this issue, so let's start by bumping the version of `cmrel` used to the latest commit.