### PR TITLE
fix: remove flock timeout as its not supported in busybox

### DIFF
--- a/modules/tools/util/lock.sh
+++ b/modules/tools/util/lock.sh
@@ -28,8 +28,6 @@ set -o pipefail
 
 finalfile="$1"
 lockfile="$finalfile.lock"
-# Timeout in seconds.
-timeout="${DOWNLOAD_TIMEOUT:-60}"
 
 # On OSX, flock is not installed, we just skip locking in that case,
 # this means that running verify in parallel without downloading all
@@ -42,8 +40,8 @@ if [[ "$flock_installed" == "yes" ]]; then
   exec {FD}<>"$lockfile"
 
   # wait for the file to be unlocked
-  if ! flock -x -w $timeout $FD; then
-    echo "Failed to obtain a lock for $lockfile within $timeout seconds"
+  if ! flock -x $FD; then
+    echo "Failed to obtain a lock for $lockfile"
     exit 1
   fi
 fi


### PR DESCRIPTION
Flock does not have the `-w` flag option in busybox, which breaks things. This removes the timeout, we can come up with something more elegant if required later