### PR TITLE
Disable gomoddirectives and gomodguard linters

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -25,8 +25,6 @@ linters:
     - gocritic
     - gofmt
     - goheader
-    - gomoddirectives
-    - gomodguard
     - goprintffuncname
     - gosec
     - gosimple


### PR DESCRIPTION
The errors returned by gomoddirectives are not very useful and cause a lot of noise.
eg.:
```
level=warning msg="[runner] Can't process result by autogenerated_exclude processor: can't filter issue result.Issue{FromLinter:\"gomoddirectives\", Text:\"replacement are not allowed: github.com/go-asn1-ber/asn1-ber\", Severity:\"\", SourceLines:[]string(nil), Replacement:(*result.Replacement)(nil), Pkg:(*packages.Package)(0xc001788a80), LineRange:(*result.Range)(nil), Pos:token.Position{Filename:\"go.mod\", Offset:0, Line:10, Column:1}, HunkPos:0, ExpectNoLint:false, ExpectedNoLintLinter:\"\"}: failed to get doc (lax) of file go.mod: failed to parse file: go.mod:1:1: expected 'package', found module"
```
Equally gomodguard is a linter that we currently do not use.

Lastly, enabling `gomoddirectives` seems to cause some issue where generated go files are no longer ignored: https://storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/6775/pull-cert-manager-master-make-verify/1785257053183283200/build-log.txt