### PR TITLE
Fix find invocations on macOS

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -46,10 +46,11 @@ shared_generate_targets += generate-govulncheck
 # not want new vulnerabilities in existing code to block the merging of PRs.
 # Instead `make verify-govulnecheck` is intended to be run periodically by a CI job.
 verify-govulncheck: | $(NEEDS_GOVULNCHECK)
-	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) -printf '%h\n' \
+	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) \
 		| while read d; do \
-				echo "Running 'GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(bin_dir)/tools/govulncheck ./...' in directory '$${d}'"; \
-				pushd "$${d}" >/dev/null; \
+				target=$$(dirname $${d}); \
+				echo "Running 'GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(bin_dir)/tools/govulncheck ./...' in directory '$${target}'"; \
+				pushd "$${target}" >/dev/null; \
 				GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(GOVULNCHECK) ./... || exit; \
 				popd >/dev/null; \
 				echo ""; \
@@ -73,10 +74,11 @@ shared_generate_targets += generate-golangci-lint-config
 ## Verify all Go modules using golangci-lint
 ## @category [shared] Generate/ Verify
 verify-golangci-lint: | $(NEEDS_GO) $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/scratch
-	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) -printf '%h\n' \
+	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) \
 		| while read d; do \
-				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config)' in directory '$${d}'"; \
-				pushd "$${d}" >/dev/null; \
+				target=$$(dirname $${d}); \
+				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config)' in directory '$${target}'"; \
+				pushd "$${target}" >/dev/null; \
 				$(GOLANGCI-LINT) run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) --timeout 4m || exit; \
 				popd >/dev/null; \
 				echo ""; \
@@ -95,10 +97,11 @@ fix-golangci-lint: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/scratch
 		-s "blank" \
 		-s "dot" .
 
-	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) -printf '%h\n' \
+	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) \
 		| while read d; do \
-				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) --fix' in directory '$${d}'"; \
-				pushd "$${d}" >/dev/null; \
+				target=$$(dirname $${d}); \
+				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) --fix' in directory '$${target}'"; \
+				pushd "$${target}" >/dev/null; \
 				$(GOLANGCI-LINT) run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) --fix || exit; \
 				popd >/dev/null; \
 				echo ""; \

--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -89,8 +89,8 @@ shared_verify_targets_dirty += verify-golangci-lint
 .PHONY: fix-golangci-lint
 ## Fix all Go modules using golangci-lint
 ## @category [shared] Generate/ Verify
-fix-golangci-lint: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/scratch
-	gci write \
+fix-golangci-lint: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(NEEDS_GCI) $(bin_dir)/scratch
+	$(GCI) write \
 		-s "standard" \
 		-s "default" \
 		-s "prefix($(repo_name))" \

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -553,7 +553,7 @@ $(DOWNLOAD_DIR)/tools/rclone@$(RCLONE_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWN
 PREFLIGHT_linux_amd64_SHA256SUM=20f31e4af2004e8e3407844afea4e973975069169d69794e0633f0cb91d45afd
 PREFLIGHT_linux_arm64_SHA256SUM=c42cf4132027d937da88da07760e8fd9b1a8836f9c7795a1b60513d99c6939fe
 
-# Currently there are no offical releases for darwin, you cannot submit results 
+# Currently there are no offical releases for darwin, you cannot submit results
 # on non-official binaries, but we can still run tests.
 #
 # Once https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/942 is merged
@@ -617,7 +617,7 @@ tools-learn-sha: | $(bin_dir)
 	HOST_OS=linux HOST_ARCH=arm64 $(MAKE) tools
 	HOST_OS=darwin HOST_ARCH=amd64 $(MAKE) tools
 	HOST_OS=darwin HOST_ARCH=arm64 $(MAKE) tools
-	
+
 	HOST_OS=linux HOST_ARCH=amd64 $(MAKE) vendor-go
 	HOST_OS=linux HOST_ARCH=arm64 $(MAKE) vendor-go
 	HOST_OS=darwin HOST_ARCH=amd64 $(MAKE) vendor-go

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -125,6 +125,8 @@ TOOLS += operator-sdk=v1.34.1
 TOOLS += gh=v2.47.0
 # https:///github.com/redhat-openshift-ecosystem/openshift-preflight/releases
 TOOLS += preflight=1.9.2
+# https://github.com/daixiang0/gci/releases/
+TOOLS += gci=v0.13.4
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION=v0.29.1
@@ -312,6 +314,7 @@ GO_DEPENDENCIES += golangci-lint=github.com/golangci/golangci-lint/cmd/golangci-
 GO_DEPENDENCIES += govulncheck=golang.org/x/vuln/cmd/govulncheck
 GO_DEPENDENCIES += operator-sdk=github.com/operator-framework/operator-sdk/cmd/operator-sdk
 GO_DEPENDENCIES += gh=github.com/cli/cli/v2/cmd/gh
+GO_DEPENDENCIES += gci=github.com/daixiang0/gci
 
 #################
 # go build tags #


### PR DESCRIPTION
Closes #130 

1. Removes non-portable arg for `find`
2. Vendors gci, which was previously assumed to be installed on the system
3. Removes some trailing whitespace from the tools module