### PR TITLE
fix 'make tools-learn-sha' on macOS

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -361,8 +361,8 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 
 go_linux_amd64_SHA256SUM=8920ea521bad8f6b7bc377b4824982e011c19af27df88a815e3586ea895f1b36
 go_linux_arm64_SHA256SUM=6c33e52a5b26e7aa021b94475587fce80043a727a54ceb0eee2f9fc160646434
-go_darwin_amd64_SHA256SUM=dd5b9303f612379caebfd12eb19e6cadee653b300443eac3a5aca341b05ad7e9
-go_darwin_arm64_SHA256SUM=58d2838f28631038ed5583c5aefb73ea4e5b13040983df21c647880f4f7dd381
+go_darwin_amd64_SHA256SUM=610e48c1df4d2f852de8bc2e7fd2dc1521aac216f0c0026625db12f67f192024
+go_darwin_arm64_SHA256SUM=02abeab3f4b8981232237ebd88f0a9bad933bc9621791cd7720a9ca29eacbe9d
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools
@@ -615,6 +615,12 @@ tools: $(tools_paths)
 
 self_file := $(dir $(lastword $(MAKEFILE_LIST)))/00_mod.mk
 
+# see https://stackoverflow.com/a/53408233
+sed_inplace := sed -i''
+ifeq ($(HOST_OS),darwin)
+	sed_inplace := sed -i ''
+endif
+
 # This target is used to learn the sha256sum of the tools. It is used only
 # in the makefile-modules repo, and should not be used in any other repo.
 .PHONY: tools-learn-sha
@@ -635,5 +641,5 @@ tools-learn-sha: | $(bin_dir)
 	HOST_OS=darwin HOST_ARCH=arm64 $(MAKE) vendor-go
 
 	while read p; do \
-		sed -i "$$p" $(self_file); \
+		$(sed_inplace) "$$p" $(self_file); \
 	done <"$(LEARN_FILE)"


### PR DESCRIPTION
Also updates shasums for darwin; I confimed manually that these are correct:

```console
$ curl -LO https://go.dev/dl/go1.22.3.darwin-arm64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    76  100    76    0     0    253      0 --:--:-- --:--:-- --:--:--   252
100 64.1M  100 64.1M    0     0  26.5M      0  0:00:02  0:00:02 --:--:-- 35.2M
$ sha256sum go1.22.3.darwin-arm64.tar.gz
02abeab3f4b8981232237ebd88f0a9bad933bc9621791cd7720a9ca29eacbe9d  go1.22.3.darwin-arm64.tar.gz
$ sha256sum go1.22.3.darwin-amd64.tar.gz
sha256sum: go1.22.3.darwin-amd64.tar.gz: No such file or directory
$ curl -LO https://go.dev/dl/go1.22.3.darwin-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    76  100    76    0     0    295      0 --:--:-- --:--:-- --:--:--   294
100 67.0M  100 67.0M    0     0  24.9M      0  0:00:02  0:00:02 --:--:-- 32.9M
$ sha256sum go1.22.3.darwin-amd64.tar.gz
610e48c1df4d2f852de8bc2e7fd2dc1521aac216f0c0026625db12f67f192024  go1.22.3.darwin-amd64.tar.gz
```