### PR TITLE
Bump kind to v0.23.0

### DIFF
--- a/modules/kind/00_mod.mk
+++ b/modules/kind/00_mod.mk
@@ -15,7 +15,7 @@
 images_amd64 ?=
 images_arm64 ?=
 
-kind_k8s_version := v1.29.2
+kind_k8s_version := v1.29.4
 
 # Goto https://github.com/kubernetes-sigs/kind/releases/tag/<KIND-VERSION> and find the
 # multi-arch digest for the image you want to use. Then use crane to get the platform
@@ -24,5 +24,5 @@ kind_k8s_version := v1.29.2
 # crane digest --platform=linux/amd64 docker.io/kindest/node@$digest
 # crane digest --platform=linux/arm64 docker.io/kindest/node@$digest
 
-images_amd64 += docker.io/kindest/node:$(kind_k8s_version)@sha256:acc9e82a5a5bd3dfccfd03117e9ef5f96b46108b55cd647fb5e7d0d1a35c9c6f
-images_arm64 += docker.io/kindest/node:$(kind_k8s_version)@sha256:068aaa834c09ab60d925a8569c6b5f5b9cf46eccf670499176f3267f2ac3189c
+images_amd64 += docker.io/kindest/node:$(kind_k8s_version)@sha256:ea40a6bd365a17f71fd3883a1d34a0791d7d6b0eb75832c6d85b6f2326827f1e
+images_arm64 += docker.io/kindest/node:$(kind_k8s_version)@sha256:e63a7f74e80b746328fbaa70be406639d0c31c8c8cf0a3d57efdd23c64fe4bba

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -50,7 +50,7 @@ tools += helm=v3.14.4
 # https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
 tools += kubectl=v1.30.0
 # https://github.com/kubernetes-sigs/kind/releases
-tools += kind=v0.22.0
+tools += kind=v0.23.0
 # https://www.vaultproject.io/downloads
 tools += vault=1.16.2
 # https://github.com/Azure/azure-workload-identity/releases
@@ -399,10 +399,10 @@ $(DOWNLOAD_DIR)/tools/kubectl@$(KUBECTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DO
 		$(checkhash_script) $(outfile) $(kubectl_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
 		chmod +x $(outfile)
 
-kind_linux_amd64_SHA256SUM=e4264d7ee07ca642fe52818d7c0ed188b193c214889dd055c929dbcb968d1f62
-kind_linux_arm64_SHA256SUM=4431805115da3b54290e3e976fe2db9a7e703f116177aace6735dfa1d8a4f3fe
-kind_darwin_amd64_SHA256SUM=28a9f7ad7fd77922c639e21c034d0f989b33402693f4f842099cd9185b144d20
-kind_darwin_arm64_SHA256SUM=c8dd3b287965150ae4db668294edc48229116e95d94620c306d8fae932ee633f
+kind_linux_amd64_SHA256SUM=1d86e3069ffbe3da9f1a918618aecbc778e00c75f838882d0dfa2d363bc4a68c
+kind_linux_arm64_SHA256SUM=a416d6c311882337f0e56910e4a2e1f8c106ec70c22cbf0ac1dd8f33c1e284fe
+kind_darwin_amd64_SHA256SUM=81c77f104b4b668812f7930659dc01ad88fa4d1cfc56900863eacdfb2731c457
+kind_darwin_arm64_SHA256SUM=68ec87c1e1ea2a708df883f4b94091150d19552d7b344e80ca59f449b301c2a0
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/kind@$(KIND_VERSION)_$(HOST_OS)_$(HOST_ARCH)
 $(DOWNLOAD_DIR)/tools/kind@$(KIND_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
Responds to the [new kind release](https://github.com/kubernetes-sigs/kind/releases/tag/v0.23.0).

Keeps our k8s version at 1.29 for now (despite support for v1.30 being added) to minimise changes we make here.

cert-manager will need additional work as a followup.