### PR TITLE
fix: pushing olm bundles to github was failing due to missing credentials

### DIFF
--- a/modules/olm-bundle/01_mod.mk
+++ b/modules/olm-bundle/01_mod.mk
@@ -93,9 +93,9 @@ olm-publish-$(subst /,-,$1): olm-bundle | $(NEEDS_GH) $(bin_dir)/scratch
 		$(if $(and $(findstring redhat-openshift-ecosystem/certified-operators,$1),$(olm_project_id)), \
 			$(YQ) -i '.cert_project_id = "$(olm_project_id)"' operators/$(olm_project_name)/ci.yaml &&) \
 		git add operators/$(olm_project_name)/ci.yaml && \
-		git commit -m "operator $(olm_project_name) ($(patsubst v%,%,$(VERSION)))" && \
-		git push origin $(VERSION) && \
-		$(GH) pr create --repo $1 --head $(firstword $(subst /, ,$2)):$(VERSION) --title "operator $(olm_project_name) ($(patsubst v%,%,$(VERSION)))"
+		git commit -m "operator $(olm_project_name) ($(VERSION))" && \
+		git push -f -c "credential.helper=!$(GH) auth git-credential" origin $(VERSION) && \
+		{ $(GH) pr create --repo $1 --head $(firstword $(subst /, ,$2)):$(VERSION) --title "operator $(olm_project_name) ($(VERSION))" ||: }
 
 olm-publish: olm-publish-$(subst /,-,$1)
 endef


### PR DESCRIPTION
When using the github cli to clone it uses `-c "credential.helper=!<path to self> auth git-credential"` on the git command to provide credentials for the clone. This means that the `gh repo clone` works. 

However due to this credentials are never set up on the repo so the push will be denied.

The fix is to do the same thing the github cli does, and set the github CLI as a credential helper for the push command.

I also make the "pr create" command not fail the build as if the PR already exists its not an error state.