### PR TITLE
Bump base images to match latest-20240603 tag

### DIFF
--- a/modules/oci-build/00_mod.mk
+++ b/modules/oci-build/00_mod.mk
@@ -16,11 +16,11 @@ oci_platforms ?= linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
 
 # Use distroless as minimal base image to package the manager binary
 # To get latest SHA run "crane digest quay.io/jetstack/base-static:latest"
-base_image_static := quay.io/jetstack/base-static@sha256:ba3cff0a4cacc5ae564e04c1f645000e8c9234c0f4b09534be1dee7874a42141
+base_image_static := quay.io/jetstack/base-static@sha256:23631cd1be9a63515cb5975e783284b209f7f9a449c02bb117f2a15413e13bfa
 
 # Use custom apko-built image as minimal base image to package the manager binary
 # To get latest SHA run "crane digest quay.io/jetstack/base-static-csi:latest"
-base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:54bacd13cccc385ef66730dbc7eb13bdb6a9ff8853e7f551d025ccb0e8c6bf83
+base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:95b33b948da3790ac09f112486a1e9f10e3e705cfacc159cb7b12429b874c78f
 
 # Utility functions
 fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))


### PR DESCRIPTION
Turns out the base images hadn't been built for months because there'd been no activity in the base images repo and so GitHub disabled the GitHub Actions workflow.

The following PRs were made to unbreak that pipeline and to fix some other stuff that had happened in meantime:

- https://github.com/cert-manager/base-images/pull/5
- https://github.com/cert-manager/base-images/pull/6
- https://github.com/cert-manager/base-images/pull/7

After these merged, the `quay.io/jetstack/base-static:latest-20240603` and `quay.io/jetstack/base-static-csi:latest-20240603` images were built.

Notably, these images are also the first to include s390x support which is required for trust-manager

See also https://github.com/jetstack/cert-manager/issues/4033