### PR TITLE
fix: add body to github PR generated by OLM publish

### DIFF
--- a/modules/olm-bundle/01_mod.mk
+++ b/modules/olm-bundle/01_mod.mk
@@ -95,7 +95,7 @@ olm-publish-$(subst /,-,$1): olm-bundle | $(NEEDS_GH) $(bin_dir)/scratch
 		git add operators/$(olm_project_name)/ci.yaml && \
 		git commit -m "operator $(olm_project_name) ($(VERSION))" && \
 		git -c "credential.helper=!$(GH) auth git-credential" push -f origin $(VERSION) && \
-		{ $(GH) pr create --repo $1 --head $(firstword $(subst /, ,$2)):$(VERSION) --title "operator $(olm_project_name) ($(VERSION))" ||:; }
+		{ $(GH) pr create --repo $1 --head $(firstword $(subst /, ,$2)):$(VERSION) --title "operator $(olm_project_name) ($(VERSION))" --body "Release of $(olm_project_name) - $(VERSION)" ||:; }
 
 olm-publish: olm-publish-$(subst /,-,$1)
 endef


### PR DESCRIPTION
The CLI fails without a body, even though PRs without a body is valid

Signed-off-by: Adam Talbot <adam.talbot@venafi.com>