### PR TITLE
Add dependabot update targets for the modules defined in the modules

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,14 +2,16 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: /
+  directories:
+    - "**/*"
   schedule:
     interval: weekly
   groups:
     all:
       patterns: ["*"]
 - package-ecosystem: github-actions
-  directory: /
+  directories:
+    - "**/*"
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
The logic for the directory path can be found here: https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_fetcher.rb#L51-L55

See also: https://github.com/dependabot/dependabot-core/issues/4899