### PR TITLE
Restrict the github-actions glob match

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,7 +11,7 @@ updates:
       patterns: ["*"]
 - package-ecosystem: github-actions
   directories:
-    - "**/*"
+    - "**/.github/workflows"
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
Should fix this issue: https://github.com/cert-manager/makefile-modules/network/updates/857554866