### PR TITLE
fix: auto-upgrade not working for OLM bundles

### DIFF
--- a/modules/olm-bundle/00_mod.mk
+++ b/modules/olm-bundle/00_mod.mk
@@ -45,6 +45,9 @@ olm_publish_repos ?=
 # program
 olm_project_id ?=
 
+# Used for handling auto-upgrade, the version that this release is replacing
+olm_replaces_version ?= $(shell git describe --tags --always --match='v*' --abbrev=0 --exclude $(VERSION))
+
 # OLMs are built as images, so can be pushed to image registries. We default the
 # tag to the version.
 #


### PR DESCRIPTION
Currently the PRs generated for OLM publishing do not auto-upgrade. This is for two reasons:
- The way upgrades are managed defaults to "replaces-mode", in which each version specifies the version it is replacing
- We do not specify the version we are replacing

This PR changes it so we default to "semver-mode" where the semver of the release is used to determine the version we are replacing

It also specifies the replaces field on top of this as the certified-operators repo seems to only use the "replaces-mode"

This should handle all cases.

Signed-off-by: Adam Talbot <adam.talbot@venafi.com>