### PR TITLE
Tools Module: require "bash" as we use bash in the main Makefile

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -615,7 +615,8 @@ $(DOWNLOAD_DIR)/tools/preflight@$(PREFLIGHT_VERSION)_linux_$(HOST_ARCH): | $(DOW
 missing=$(shell (command -v curl >/dev/null || echo curl) \
              && (command -v sha256sum >/dev/null || command -v shasum >/dev/null || echo sha256sum) \
              && (command -v git >/dev/null || echo git) \
-             && (command -v rsync >/dev/null || echo rsync))
+             && (command -v rsync >/dev/null || echo rsync) \
+             && (command -v bash >/dev/null || echo bash))
 ifneq ($(missing),)
 $(error Missing required tools: $(missing))
 endif


### PR DESCRIPTION
I've noticed that we have the following in the base Makefile:

https://github.com/cert-manager/makefile-modules/blob/2547c81aaa2ff4aeefdda53988191b5cbe929985/modules/repository-base/base/Makefile#L42

But we don't require bash anywhere, which breaks Makefile Modules on systems that don't have Bash installed (e.g., in a Debian container).

It feels a little weird to see that one has to rely on the module `tools` to make the base Makefile work... I guess we should call that out in the base Makefile?