### PR TITLE
generate-crds: don't include dirs that are in git-ignored

### DIFF
--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -42,7 +42,7 @@ endif
 ## @category [shared] Generate/ Verify
 generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
 	$(eval crds_gen_temp := $(bin_dir)/scratch/crds)
-	$(eval directories := $(shell ls -d */ | grep -v '_bin' | grep -v 'make'))
+  $(eval directories := $(shell ls -d */ | grep -v -e '_bin' -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
 
 	rm -rf $(crds_gen_temp)
 	mkdir -p $(crds_gen_temp)

--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -42,7 +42,7 @@ endif
 ## @category [shared] Generate/ Verify
 generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
 	$(eval crds_gen_temp := $(bin_dir)/scratch/crds)
-  $(eval directories := $(shell ls -d */ | grep -v -e '_bin' -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
+	$(eval directories := $(shell ls -d */ | grep -v -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
 
 	rm -rf $(crds_gen_temp)
 	mkdir -p $(crds_gen_temp)


### PR DESCRIPTION
In all of my projects, I use a special `mine/` folder that I ignore using:

```
cat >>.git/info/exclude <<< "mine/"
```

The problem arises when I put Go files under `mine/`. When running `make generate-crds`, I end up with the following:

```console
$ make generate-crds                                        
rm -rf _bin/scratch/crds
mkdir -p _bin/scratch/crds
/Users/mvalais/code/jetstack/jetstack-secure/_bin/tools/controller-gen crd \
                paths=./api/... paths=./cmd/... paths=./deploy/... paths=./docs/... paths=./examples/... paths=./hack/... paths=./mine/... paths=./pkg/... \
                output:crd:artifacts:config=_bin/scratch/crds
Error: load packages in root "/Users/mvalais/code/jetstack/jetstack-secure/mine": err: exit status 1: stderr: go: cannot load module . listed in go.work file: open go.mod: no such file or directory
go: cannot load module ../../cert-manager/issuer-lib listed in go.work file: open ../../cert-manager/issuer-lib/go.mod: no such file or directory
go: cannot load module ../venafi-connection-lib listed in go.work file: open ../venafi-connection-lib/go.mod: no such file or directory
```

I suggest that we ignore the folders that have been ignored in `./.gitignore`, `~/.gitignore`, or in `.git/info/exclude`.

WDYT?