### PR TITLE
fix: gci write should skip generated/vendor

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -126,6 +126,8 @@ shared_verify_targets_dirty += verify-golangci-lint
 ## @category [shared] Generate/ Verify
 fix-golangci-lint: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(NEEDS_GCI) $(bin_dir)/scratch
 	$(GCI) write \
+		--skip-generated \
+		--skip-vendor \
 		-s "standard" \
 		-s "default" \
 		-s "prefix($(repo_name))" \


### PR DESCRIPTION
Some generated files in trust-manger doesn't follow the gci-configured order of imports, which makes it harder to use `make fix-golangci-lint` in trust-manager. This PR configures gci to skip generated (and vendor) files. This aligns with the default gci configuration in golangci-lint: https://golangci-lint.run/usage/linters/#gci

I wonder if/why we need to run gci separately in `make fix-golangci-lint` - as the golangci-lint docs state that gci supports autofix, but that can eventually be addressed as a follow-up.

![image](https://github.com/user-attachments/assets/09cb8e0f-46e6-4517-960b-2f6795e86797)
