### PR TITLE
chore: remove deprecated execinquery linter

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -14,7 +14,6 @@ linters:
     - errcheck
     - errchkjson
     - errname
-    - execinquery
     - exhaustive
     - exportloopref
     - forbidigo


### PR DESCRIPTION
While looking into the failing self-upgrade in approver-policy, I noticed a warning:

````
Running '_bin/tools/golangci-lint run --go 1.23.0 -c /home/erikbo/projects/github/approver-policy/.golangci.yaml --fix' in directory '.'
WARN The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner.  
````

This removes the deprecated linter from our golangci-lint configuration.

/cc @inteon 