### PR TITLE
Add variable to configure the Helm chart app version

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -32,6 +32,11 @@ ifndef helm_chart_version
 $(error helm_chart_version is not set)
 endif
 
+ifndef helm_chart_app_version
+# Default to the same as the chart version
+helm_chart_app_version = $(helm_chart_version)
+endif
+
 ifndef helm_values_mutation_function
 $(error helm_values_mutation_function is not set)
 endif
@@ -59,7 +64,7 @@ $(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_d
 
 	mkdir -p $(dir $@)
 	$(HELM) package $(helm_chart_source_dir_versioned) \
-		--app-version $(helm_chart_version) \
+		--app-version $(helm_chart_app_version) \
 		--version $(helm_chart_version) \
 		--destination $(dir $@)
 


### PR DESCRIPTION
This will make it easier to configure the app version to be eg. "v0.5.0" and the chart version to be "0.5.0".
We can use this change in https://github.com/cert-manager/openshift-routes to make sure the app version matches the image tag.