### PR TITLE
Limit self-upgrade to cert-manager org

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -15,6 +15,8 @@ jobs:
   self_upgrade:
     runs-on: ubuntu-latest
 
+    if: github.repository_owner == 'cert-manager'
+
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Fixes cert-manager/cert-manager#7183

See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs