### PR TITLE
Add helm_dont_include_crds option

### DIFF
--- a/modules/helm/01_mod.mk
+++ b/modules/helm/01_mod.mk
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ifndef helm_dont_include_crds
 include $(dir $(lastword $(MAKEFILE_LIST)))/crds.mk
+endif
+
 include $(dir $(lastword $(MAKEFILE_LIST)))/helm.mk
 include $(dir $(lastword $(MAKEFILE_LIST)))/deploy.mk


### PR DESCRIPTION
This option can be used to disable the auto CRD generation, so it can be replaced with custom logic instead.