### PR TITLE
Add the -n flag to the 'ln' command

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -183,7 +183,11 @@ CURL := curl --silent --show-error --fail --location --retry 10 --retry-connrefu
 # can run the "link $(DOWNLOAD_DIR)/tools/xxx@$(XXX_VERSION)_$(HOST_OS)_$(HOST_ARCH)
 # to $(bin_dir)/tools/xxx" operation simultaneously without issues (both
 # will perform the action and the second time the link will be overwritten).
-LN := ln -fs
+#
+# -s = Create a symbolic link
+# -f = Force the creation of the link (replace existing links)
+# -n = If destination already exists, replace it, don't use it as a directory to create a new link inside
+LN := ln -fsn
 
 upper_map := a:A b:B c:C d:D e:E f:F g:G h:H i:I j:J k:K l:L m:M n:N o:O p:P q:Q r:R s:S t:T u:U v:V w:W x:X y:Y z:Z
 uc = $(strip \


### PR DESCRIPTION
This will make such that destination directories are overwritten if they exist already (instead of creating a new directory link inside the destination directory).

Before (when upgrading the vendored Go version):
1. `_bin/tools/goroot` points to go 1.23.1
2. `_bin/tools/goroot/goroot` was created and points to go 1.23.2

Now:
1. `_bin/tools/goroot` points to go 1.23.1
2. `_bin/tools/goroot` was replaced and points to go 1.23.2