### PR TITLE
Upgrade helm-tool to v0.5.3

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -117,7 +117,7 @@ tools += goreleaser=v1.26.2
 # https://pkg.go.dev/github.com/anchore/syft/cmd/syft?tab=versions
 tools += syft=v0.100.0
 # https://github.com/cert-manager/helm-tool
-tools += helm-tool=v0.5.1
+tools += helm-tool=v0.5.3
 # https://github.com/cert-manager/cmctl
 tools += cmctl=v2.1.0
 # https://pkg.go.dev/github.com/cert-manager/release/cmd/cmrel?tab=versions


### PR DESCRIPTION
See https://github.com/cert-manager/helm-tool/releases/tag/v0.5.2 and https://github.com/cert-manager/helm-tool/releases/tag/v0.5.3 for more info.