### PR TITLE
feat: Make generated CRDs directly available for testing and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 _bin
+.idea/
+*.iml

--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -37,29 +37,29 @@ ifeq ($(HOST_OS),darwin)
 	sed_inplace := sed -i ''
 endif
 
+crds_dir ?= config/crd/bases
+
 .PHONY: generate-crds
 ## Generate CRD manifests.
 ## @category [shared] Generate/ Verify
 generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
-	$(eval crds_gen_temp := $(bin_dir)/scratch/crds)
 	$(eval directories := $(shell ls -d */ | grep -v -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
 
-	rm -rf $(crds_gen_temp)
-	mkdir -p $(crds_gen_temp)
+	mkdir -p $(crds_dir)
 
 	$(CONTROLLER-GEN) crd \
 		$(directories:%=paths=./%...) \
-		output:crd:artifacts:config=$(crds_gen_temp)
+		output:crd:artifacts:config=$(crds_dir)
 
 	echo "Updating CRDs with helm templating, writing to $(helm_chart_source_dir)/templates"
 
-	@for i in $$(ls $(crds_gen_temp)); do \
-		crd_name=$$($(YQ) eval '.metadata.name' $(crds_gen_temp)/$$i); \
+	@for i in $$(ls $(crds_dir)); do \
+		crd_name=$$($(YQ) eval '.metadata.name' $(crds_dir)/$$i); \
 		cat $(crd_template_header) > $(helm_chart_source_dir)/templates/crd-$$i; \
 		echo "" >> $(helm_chart_source_dir)/templates/crd-$$i; \
 		$(sed_inplace) "s/REPLACE_CRD_NAME/$$crd_name/g" $(helm_chart_source_dir)/templates/crd-$$i; \
 		$(sed_inplace) "s/REPLACE_LABELS_TEMPLATE/$(helm_labels_template_name)/g" $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(YQ) -I2 '{"spec": .spec}' $(crds_gen_temp)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
+		$(YQ) -I2 '{"spec": .spec}' $(crds_dir)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
 		cat $(crd_template_footer) >> $(helm_chart_source_dir)/templates/crd-$$i; \
 	done
 


### PR DESCRIPTION
I think the CRDs generated by controller-gen deserves to be available in our projects, and not just temporary files used as input to Helm CRD templates. While this will semi-duplicate the CRDs in project repositories, I think it has a lot of benefits (not limited to):

- Making CRD manifests available in projects, and not just wrapped in a Helm chart.
- Easier to publish CRDs as a release artifact on releases, which is requested in several issues across the cert-manager org.
- Avoiding pitfalls such as https://github.com/cert-manager/trust-manager/blob/main/test/integration/bundle/integration.go#L41, which is a semi-blocker for running integration tests for IDEs.

I have suggested the default kubebuilder path for CRD manifests, even if we don't use/require kubebuilder in our projects. Open for other suggestions, but I think the term "bases" is important - as I think we can use kustomize to transform CRD in other use cases.