### PR TITLE
Revert "Add govet shadow linter"

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -59,11 +59,6 @@ linters:
     - usestdlibvars
     - wastedassign
 linters-settings:
-  govet:
-    enable: ["shadow"]
-    settings:
-      shadow:
-        strict: true
   gci:
     sections:
       - standard # Standard section: captures all standard packages.


### PR DESCRIPTION
This reverts commit bd2e35e507abfa6a5c6f02708b19e32f8351e712 from https://github.com/cert-manager/makefile-modules/pull/190.

We found that linter created too many violations, with lots of false positives:
```
shadow: declaration of "err" shadows declaration at line 106 (govet)
		if err := adminClient.Create(ctx, crd); err != nil {
```

```
shadow: declaration of "fldPath" shadows declaration at line 52 (govet)
		fldPath := fldPath.Child("privateKey")
```
