### PR TITLE
Update OWNERS files to match current maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,16 +4,17 @@ approvers:
 - wallrj
 - jakexks
 - maelvls
-- irbekrm
 - sgtcodfish
 - inteon
+- thatsmrtalbot
+- erikgb
 reviewers:
 - munnerz
 - joshvanl
 - wallrj
 - jakexks
 - maelvls
-- irbekrm
 - sgtcodfish
 - inteon
 - thatsmrtalbot
+- erikgb

--- a/modules/repository-base/base/OWNERS_ALIASES
+++ b/modules/repository-base/base/OWNERS_ALIASES
@@ -8,7 +8,7 @@ aliases:
     - wallrj
     - jakexks
     - maelvls
-    - irbekrm
     - sgtcodfish
     - inteon
     - thatsmrtalbot
+    - erikgb


### PR DESCRIPTION
Based on the list of maintainers: https://github.com/cert-manager/community/blob/a3f74f738bf1784ab542b668b22842f4947ede9f/maintainers.csv