### PR TITLE
Tools: bump openshift-preflight, gh, operator-sdk and others

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -116,28 +116,30 @@ tools += ginkgo=$(detected_ginkgo_version)
 tools += klone=v0.1.0
 # https://pkg.go.dev/github.com/goreleaser/goreleaser?tab=versions
 tools += goreleaser=v1.26.2
-# https://pkg.go.dev/github.com/anchore/syft/cmd/syft?tab=versions
+# https://pkg.go.dev/github.com/anchore/syft/cmd/syft?tab=versions. We are still
+# using an old version (0.100.0, Jan 2024) because all of the latest versions
+# use a replace statement, and thus cannot be installed using `go build`.
 tools += syft=v0.100.0
 # https://github.com/cert-manager/helm-tool
 tools += helm-tool=v0.5.3
 # https://github.com/cert-manager/cmctl
-tools += cmctl=v2.1.0
+tools += cmctl=v2.1.1
 # https://pkg.go.dev/github.com/cert-manager/release/cmd/cmrel?tab=versions
-tools += cmrel=e4c3a4dc07df5c7c0379d334c5bb00e172462551
+tools += cmrel=e3cbe5171488deda000145003e22567bdce622ea
 # https://github.com/golangci/golangci-lint/releases
-tools += golangci-lint=v1.61.0
+tools += golangci-lint=v1.62.2
 # https://pkg.go.dev/golang.org/x/vuln?tab=versions
 tools += govulncheck=v1.1.3
 # https://pkg.go.dev/github.com/operator-framework/operator-sdk/cmd/operator-sdk?tab=versions
-tools += operator-sdk=v1.36.1
+tools += operator-sdk=v1.38.0
 # https://pkg.go.dev/github.com/cli/cli/v2?tab=versions
-tools += gh=v2.54.0
+tools += gh=v2.63.1
 # https:///github.com/redhat-openshift-ecosystem/openshift-preflight/releases
-tools += preflight=1.10.0
+tools += preflight=1.10.2
 # https://github.com/daixiang0/gci/releases
-tools += gci=v0.13.4
+tools += gci=v0.13.5
 # https://github.com/google/yamlfmt/releases
-tools += yamlfmt=v0.13.0
+tools += yamlfmt=v0.14.0
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION := v0.31.0


### PR DESCRIPTION
While working on an internal Venafi project (namely, [venafi-installer-operator](https://gitlab.com/venafi/vaas/applications/tls-protect-for-k8s/venafi-installer-operator/-/merge_requests/67#note_2242999888)), I found that the openshift-preflight image tag we used wasn't accepted by Red Hat anymore:

```
time="2024-12-05T09:17:59Z" level=error msg=release-url error="invalid preflight version, please download the latest version and re-submit"
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.10.0' is not supported. Supported versions are: ['1.10.1', '1.10.2']", "status": 400, "trace_id": "0xe9a0d036a9535370c17a24daf58bc8d7"}
```

I've also updated the other tools, but haven't updated `syft`. I've kept the old version (0.100.0, Jan 2024) because all of the latest versions use a replace statement, and thus cannot be installed using `go build`:

```
go: github.com/anchore/syft/cmd/syft@v1.17.0 (in github.com/anchore/syft@v1.17.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```