### PR TITLE
Forgot to run `make learn-tools-shas`

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -600,8 +600,8 @@ $(DOWNLOAD_DIR)/tools/istioctl@$(ISTIOCTL_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(
 		chmod +x $(outfile); \
 		rm $(outfile).tar.gz
 
-preflight_linux_amd64_SHA256SUM=97750df31f31200f073e3b2844628a0a3681a403648c76d12319f83c80666104
-preflight_linux_arm64_SHA256SUM=e12b2afe063c07ee75f69f285f8cc56be99b85e2abac99cbef5fb22b91ef0cb7
+preflight_linux_amd64_SHA256SUM=776d04669304d3185c40522bed9a6dc1aa9cd80014a203fe01552b98bfa9554b
+preflight_linux_arm64_SHA256SUM=dd7b0a144892ce6fc47d1bc44e344130fa9ff997bf2c39de3016873d8bd3fac5
 
 # Currently there are no official releases for darwin, you cannot submit results
 # on non-official binaries, but we can still run tests.


### PR DESCRIPTION
This is a follow-up to https://github.com/cert-manager/makefile-modules/pull/216. I forgot to run make `learn-tools-shas`.

Before:

```console
$ make $PWD/_bin/downloaded/tools/preflight@1.10.2_linux_amd64 HOST_OS=linux HOST_ARCH=amd64
invalid checksum for "/Users/mael.valais/code/cert-manager/makefile-modules/_bin/downloaded/tools/preflight@1.10.2_linux_amd64.tmp": wanted "97750df31f31200f073e3b2844628a0a3681a403648c76d12319f83c80666104" but got "776d04669304d3185c40522bed9a6dc1aa9cd80014a203fe01552b98bfa9554b"
make: *** [/Users/mael.valais/code/cert-manager/makefile-modules/_bin/downloaded/tools/preflight@1.10.2_linux_amd64] Error 1
```


```console
$ make $PWD/_bin/downloaded/tools/preflight@1.10.2_linux_arm64 HOST_OS=linux HOST_ARCH=arm64
invalid checksum for "/Users/mael.valais/code/cert-manager/makefile-modules/_bin/downloaded/tools/preflight@1.10.2_linux_arm64.tmp": wanted "e12b2afe063c07ee75f69f285f8cc56be99b85e2abac99cbef5fb22b91ef0cb7" but got "dd7b0a144892ce6fc47d1bc44e344130fa9ff997bf2c39de3016873d8bd3fac5"
make: *** [/Users/mael.valais/code/cert-manager/makefile-modules/_bin/downloaded/tools/preflight@1.10.2_linux_arm64] Error 1
```

After:

```console
$ make $PWD/_bin/downloaded/tools/preflight@1.10.2_linux_amd64 HOST_OS=linux HOST_ARCH=amd64
[info]: downloaded /Users/mael.valais/code/cert-manager/makefile-modules/_bin/downloaded/tools/preflight@1.10.2_linux_amd64
```

```console
$ make $PWD/_bin/downloaded/tools/preflight@1.10.2_linux_arm64 HOST_OS=linux HOST_ARCH=arm64
[info]: downloaded /Users/mael.valais/code/cert-manager/makefile-modules/_bin/downloaded/tools/preflight@1.10.2_linux_arm64
```