### PR TITLE
Remove helm_docs_use_helm_tool, helm_generate_schema and helm_verify_values options

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -73,8 +73,6 @@ $(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_d
 ## @category [shared] Helm Chart
 helm-chart: $(helm_chart_archive)
 
-ifdef helm_docs_use_helm_tool
-
 helm_tool_header_search ?= ^<!-- AUTO-GENERATED -->
 helm_tool_footer_search ?= ^<!-- /AUTO-GENERATED -->
 
@@ -83,17 +81,9 @@ helm_tool_footer_search ?= ^<!-- /AUTO-GENERATED -->
 ## @category [shared] Generate/ Verify
 generate-helm-docs: | $(NEEDS_HELM-TOOL)
 	$(HELM-TOOL) inject -i $(helm_chart_source_dir)/values.yaml -o $(helm_chart_source_dir)/README.md --header-search "$(helm_tool_header_search)" --footer-search "$(helm_tool_footer_search)"
-else
-.PHONY: generate-helm-docs
-## Generate Helm chart documentation.
-## @category [shared] Generate/ Verify
-generate-helm-docs: | $(NEEDS_HELM-DOCS)
-	$(HELM-DOCS) $(helm_chart_source_dir)/
-endif
 
 shared_generate_targets += generate-helm-docs
 
-ifdef helm_generate_schema
 .PHONY: generate-helm-schema
 ## Generate Helm chart schema.
 ## @category [shared] Generate/ Verify
@@ -101,9 +91,7 @@ generate-helm-schema: | $(NEEDS_HELM-TOOL) $(NEEDS_GOJQ)
 	$(HELM-TOOL) schema -i $(helm_chart_source_dir)/values.yaml | $(GOJQ) > $(helm_chart_source_dir)/values.schema.json
 
 shared_generate_targets += generate-helm-schema
-endif
 
-ifdef helm_verify_values
 .PHONY: verify-helm-values
 ## Verify Helm chart values using helm-tool.
 ## @category [shared] Generate/ Verify
@@ -111,7 +99,6 @@ verify-helm-values: | $(NEEDS_HELM-TOOL) $(NEEDS_GOJQ)
 	$(HELM-TOOL) lint -i $(helm_chart_source_dir)/values.yaml -d $(helm_chart_source_dir)/templates -e $(helm_chart_source_dir)/values.linter.exceptions
 
 shared_verify_targets += verify-helm-values
-endif
 
 .PHONY: verify-pod-security-standards
 ## Verify that the Helm chart complies with the pod security standards.

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -95,8 +95,6 @@ tools += gojq=v0.12.16
 tools += crane=v0.20.2
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions
 tools += protoc-gen-go=v1.34.2
-# https://pkg.go.dev/github.com/norwoodj/helm-docs/cmd/helm-docs?tab=versions
-tools += helm-docs=v1.14.2
 # https://pkg.go.dev/github.com/sigstore/cosign/v2/cmd/cosign?tab=versions
 tools += cosign=v2.4.0
 # https://pkg.go.dev/github.com/cert-manager/boilersuite?tab=versions
@@ -324,7 +322,6 @@ go_dependencies += kustomize=sigs.k8s.io/kustomize/kustomize/v4
 go_dependencies += gojq=github.com/itchyny/gojq/cmd/gojq
 go_dependencies += crane=github.com/google/go-containerregistry/cmd/crane
 go_dependencies += protoc-gen-go=google.golang.org/protobuf/cmd/protoc-gen-go
-go_dependencies += helm-docs=github.com/norwoodj/helm-docs/cmd/helm-docs
 go_dependencies += cosign=github.com/sigstore/cosign/v2/cmd/cosign
 go_dependencies += boilersuite=github.com/cert-manager/boilersuite
 go_dependencies += gomarkdoc=github.com/princjef/gomarkdoc/cmd/gomarkdoc


### PR DESCRIPTION
All repos using the Helm module now have these options enabled, making them useless and adding extra complexity.