### PR TITLE
fix: should include README.md in generated CRDs directory

### DIFF
--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -49,7 +49,7 @@ $(crds_dir)/README.md: $(crds_dir_readme) | $(crds_dir)
 .PHONY: generate-crds
 ## Generate CRD manifests.
 ## @category [shared] Generate/ Verify
-generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
+generate-crds: | $(crds_dir)/README.md $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
 	$(eval directories := $(shell ls -d */ | grep -v -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
 
 	$(CONTROLLER-GEN) crd \


### PR DESCRIPTION
This is a bugfix to https://github.com/cert-manager/makefile-modules/pull/214, see https://github.com/cert-manager/makefile-modules/pull/214#issuecomment-2532266310.

/cc @inteon 