### PR TITLE
Fix issues with CRD generation (in repos that don't have CRDs)

### DIFF
--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -40,32 +40,35 @@ endif
 crds_dir ?= deploy/crds
 crds_dir_readme := $(dir $(lastword $(MAKEFILE_LIST)))/crds_dir.README.md
 
-$(crds_dir):
-	mkdir -p $@
-
-$(crds_dir)/README.md: $(crds_dir_readme) | $(crds_dir)
-	cp $< $@
-
 .PHONY: generate-crds
 ## Generate CRD manifests.
 ## @category [shared] Generate/ Verify
-generate-crds: | $(crds_dir)/README.md $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
+generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
+	$(eval crds_gen_temp := $(bin_dir)/scratch/crds)
 	$(eval directories := $(shell ls -d */ | grep -v -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
+
+	rm -rf $(crds_gen_temp)
+	mkdir -p $(crds_gen_temp)
 
 	$(CONTROLLER-GEN) crd \
 		$(directories:%=paths=./%...) \
-		output:crd:artifacts:config=$(crds_dir)
+		output:crd:artifacts:config=$(crds_gen_temp)
 
-	echo "Updating CRDs with helm templating, writing to $(helm_chart_source_dir)/templates"
+	@echo "Updating CRDs with helm templating, writing to $(helm_chart_source_dir)/templates"
 
-	@for i in $$(basename $(crds_dir)/*.yaml); do \
-		crd_name=$$($(YQ) eval '.metadata.name' $(crds_dir)/$$i); \
+	@for i in $$(ls $(crds_gen_temp)); do \
+		crd_name=$$($(YQ) eval '.metadata.name' $(crds_gen_temp)/$$i); \
 		cat $(crd_template_header) > $(helm_chart_source_dir)/templates/crd-$$i; \
 		echo "" >> $(helm_chart_source_dir)/templates/crd-$$i; \
 		$(sed_inplace) "s/REPLACE_CRD_NAME/$$crd_name/g" $(helm_chart_source_dir)/templates/crd-$$i; \
 		$(sed_inplace) "s/REPLACE_LABELS_TEMPLATE/$(helm_labels_template_name)/g" $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(YQ) -I2 '{"spec": .spec}' $(crds_dir)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
+		$(YQ) -I2 '{"spec": .spec}' $(crds_gen_temp)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
 		cat $(crd_template_footer) >> $(helm_chart_source_dir)/templates/crd-$$i; \
 	done
+
+	@if [ -n "$$(ls $(crds_gen_temp) 2>/dev/null)" ]; then \
+		cp -Tr $(crds_gen_temp) $(crds_dir); \
+		cp $(crds_dir_readme) $(crds_dir)/README.md; \
+	fi
 
 shared_generate_targets += generate-crds


### PR DESCRIPTION
Generates the CRDs using `CONTROLLER-GEN` in a temporary directory and only creates the `crds_dir` directory if that folder is non-empty.