### PR TITLE
Test downloading kind, kubectl, etcd and go

### DIFF
--- a/tests/e2e-projects/test-project/test-config.sh
+++ b/tests/e2e-projects/test-project/test-config.sh
@@ -33,4 +33,8 @@ targets_to_run+=(
     "docker-tarball-manager"
     "help"
     "verify"
+    "_bin/tools/kind"
+    "_bin/tools/kubectl"
+    "_bin/tools/etcd"
+    "vendor-go"
 )


### PR DESCRIPTION
Expands the e2e test that runs on each PR to include downloading kind, kubectl, etcd and go.