### PR TITLE
Speedup learn-tools-shas script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ upgrade-kind-images: | $(NEEDS_CRANE)
 # version has been bumped.
 .PHONY: learn-tools-shas
 learn-tools-shas: | $(NEEDS_CRANE)
-	./scripts/learn_tools_shas.sh tools _bin/tools/go
+	./scripts/learn_tools_shas.sh non-go-tools _bin/tools/go
 	@CRANE=$(CRANE) \
 		./scripts/learn_kind_images.sh
 

--- a/scripts/learn_tools_shas.sh
+++ b/scripts/learn_tools_shas.sh
@@ -27,7 +27,7 @@ script_dir=$(dirname "$(realpath "$0")")
 tool_targets=("$@")
 if [ ${#tool_targets[@]} -eq 0 ]; then
     echo "Usage: $0 <tool-target>..."
-    echo "Example 1: $0 tools _bin/tools/go"
+    echo "Example 1: $0 non-go-tools _bin/tools/go"
     echo "Example 2: $0 _bin/tools/helm _bin/tools/kubectl"
     exit 1
 fi


### PR DESCRIPTION
The non-go-tools target now only downloads the tools that have shas (the non-go ones).