### PR TITLE
Fix self-upgrade failure due to invalid version returned by git describe in CI

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -33,6 +33,10 @@ jobs:
           exit 1
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
 
       - id: go-version
         run: |


### PR DESCRIPTION
See https://github.com/cert-manager/trust-manager/actions/runs/12393729213 and https://github.com/cert-manager/trust-manager/actions/runs/12393952730 for the before and after resp.