### PR TITLE
Fetch git tags in vulncheck GH action

### DIFF
--- a/modules/go/base/.github/workflows/govulncheck.yaml
+++ b/modules/go/base/.github/workflows/govulncheck.yaml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
 
       - id: go-version
         run: |


### PR DESCRIPTION
Similar to https://github.com/cert-manager/makefile-modules/pull/233 for the vulncheck action.