### PR TITLE
Rename and add go build options and make them work for both oci-build and executable modules

### DIFF
--- a/modules/executable/00_mod.mk
+++ b/modules/executable/00_mod.mk
@@ -1,0 +1,79 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exe_targets ?= darwin_amd64_v1,darwin_arm64,linux_amd64_v1,linux_arm_7,linux_arm64,linux_ppc64le,linux_s390x,windows_amd64_v1,windows_arm64
+
+# Utility functions
+fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))
+
+# Validate globals that are required
+$(call fatal_if_undefined,bin_dir)
+$(call fatal_if_undefined,exe_build_names)
+$(call fatal_if_undefined,gorelease_file)
+
+# Set default config values
+CGO_ENABLED ?= 0
+GOEXPERIMENT ?=  # empty by default
+
+# Default variables per exe_build_names entry
+#
+# $1 - build_name
+define default_per_build_variables
+go_$1_cgo_enabled ?= $(CGO_ENABLED)
+go_$1_goexperiment ?= $(GOEXPERIMENT)
+go_$1_flags ?= -tags=
+endef
+
+$(foreach build_name,$(exe_build_names),$(eval $(call default_per_build_variables,$(build_name))))
+
+# Validate variables per exe_build_names entry
+#
+# $1 - build_name
+define check_per_build_variables
+# Validate required config exists
+$(call fatal_if_undefined,go_$1_ldflags)
+$(call fatal_if_undefined,go_$1_main_dir)
+$(call fatal_if_undefined,go_$1_mod_dir)
+
+# Validate the config required to build the golang based executable
+ifneq ($(go_$1_main_dir:.%=.),.)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES start with ".")
+endif
+ifeq ($(go_$1_main_dir:%/=/),/)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_main_dir:%.go=.go),.go)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+ifneq ($(go_$1_mod_dir:.%=.),.)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES start with ".")
+endif
+ifeq ($(go_$1_mod_dir:%/=/),/)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_mod_dir:%.go=.go),.go)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+ifeq ($(wildcard $(go_$1_mod_dir)/go.mod),)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" does not contain a go.mod file)
+endif
+ifeq ($(wildcard $(go_$1_mod_dir)/$(go_$1_main_dir)/main.go),)
+$$(error go_$1_main_dir "$(go_$1_mod_dir)" does not contain a main.go file)
+endif
+endef
+
+$(foreach build_name,$(exe_build_names),$(eval $(call check_per_build_variables,$(build_name))))
+
+# Dryrun release
+RELEASE_DRYRUN ?= false

--- a/modules/licenses/00_mod.mk
+++ b/modules/licenses/00_mod.mk
@@ -50,6 +50,6 @@ oci-license-layer-%: | $(bin_dir)/scratch $$(NEEDS_GO-LICENSES)
 # Add the license layer to every image
 define licences_layer_dependencies
 oci-build-$1: oci-license-layer-$1
-oci_additional_layers_$1 += $(license_layer_path_$1)
+oci_$1_additional_layers += $(license_layer_path_$1)
 endef
 $(foreach build_name,$(build_names),$(eval $(call licences_layer_dependencies,$(build_name))))

--- a/modules/oci-build/00_mod.mk
+++ b/modules/oci-build/00_mod.mk
@@ -24,6 +24,7 @@ base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:c30595ad2eed496
 
 # Utility functions
 fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))
+fatal_if_deprecated_defined = $(if $(findstring undefined,$(origin $1)),,$(error $1 is deprecated, use $2 instead))
 
 # Validate globals that are required
 $(call fatal_if_undefined,bin_dir)
@@ -37,9 +38,11 @@ GOEXPERIMENT ?=  # empty by default
 #
 # $1 - build_name
 define default_per_build_variables
-cgo_enabled_$1 ?= $(CGO_ENABLED)
-goexperiment_$1 ?= $(GOEXPERIMENT)
-oci_additional_layers_$1 ?= 
+go_$1_cgo_enabled ?= $(CGO_ENABLED)
+go_$1_goexperiment ?= $(GOEXPERIMENT)
+go_$1_flags ?= -tags=
+oci_$1_additional_layers ?= 
+oci_$1_linux_capabilities ?= 
 endef
 
 $(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(build_name))))
@@ -48,6 +51,11 @@ $(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(
 #
 # $1 - build_name
 define check_per_build_variables
+# Validate deprecated variables
+$(call fatal_if_deprecated_defined,cgo_enabled_$1,go_$1_cgo_enabled)
+$(call fatal_if_deprecated_defined,goexperiment_$1,go_$1_goexperiment)
+$(call fatal_if_deprecated_defined,oci_additional_layers_$1,oci_$1_additional_layers)
+
 # Validate required config exists
 $(call fatal_if_undefined,go_$1_ldflags)
 $(call fatal_if_undefined,go_$1_main_dir)

--- a/modules/oci-build/01_mod.mk
+++ b/modules/oci-build/01_mod.mk
@@ -31,11 +31,13 @@ $(ko_config_path_$1:$(CURDIR)/%=%): | $(NEEDS_YQ) $(bin_dir)/scratch/image
 		$(YQ) '.builds[0].id = "$1"' | \
 		$(YQ) '.builds[0].dir = "$(go_$1_mod_dir)"' | \
 		$(YQ) '.builds[0].main = "$(go_$1_main_dir)"' | \
-		$(YQ) '.builds[0].env[0] = "CGO_ENABLED=$(cgo_enabled_$1)"' | \
-		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT=$(goexperiment_$1)"' | \
+		$(YQ) '.builds[0].env[0] = "CGO_ENABLED=$(go_$1_cgo_enabled)"' | \
+		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT=$(go_$1_goexperiment)"' | \
 		$(YQ) '.builds[0].ldflags[0] = "-s"' | \
 		$(YQ) '.builds[0].ldflags[1] = "-w"' | \
-		$(YQ) '.builds[0].ldflags[2] = "{{.Env.LDFLAGS}}"' \
+		$(YQ) '.builds[0].ldflags[2] = "{{.Env.LDFLAGS}}"' | \
+		$(YQ) '.builds[0].flags[0] = "$(go_$1_flags)"' | \
+		$(YQ) '.builds[0].linux_capabilities = "$(oci_$1_linux_capabilities)"' \
 		> $(CURDIR)/$(oci_layout_path_$1).ko_config.yaml
 
 ko-config-$1: $(ko_config_path_$1:$(CURDIR)/%=%)
@@ -66,7 +68,7 @@ $(oci_build_targets): oci-build-%: ko-config-% | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS
 
 	$(IMAGE_TOOL) append-layers \
 		$(CURDIR)/$(oci_layout_path_$*) \
-		$(oci_additional_layers_$*)
+		$(oci_$*_additional_layers)
 
 	$(IMAGE_TOOL) list-digests \
 		$(CURDIR)/$(oci_layout_path_$*) \


### PR DESCRIPTION
- added `go_$1_flags`
- added `oci_$1_linux_capabilities`
- renamed `cgo_enabled_$1` to `go_$1_cgo_enabled` (to match the naming pattern used for all other go-related variables)
- renamed `goexperiment_$1` to `go_$1_goexperiment` (to match the naming pattern used for all other go-related variables)
- renamed `oci_additional_layers_$1` to `oci_$1_additional_layers` (to match the naming pattern used for all other oci-related variables)
- `build_names` are no longer included in the `executable` module, explicitly use `exe_build_names` instead

This PR will fix the renamed variable for the trust-manager project (only OSS project that uses these variables):
https://github.com/cert-manager/trust-manager/pull/538