### PR TITLE
Stop trying to rm CRDs dir

### DIFF
--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -47,11 +47,6 @@ generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
 	$(eval crds_gen_temp := $(bin_dir)/scratch/crds)
 	$(eval directories := $(shell ls -d */ | grep -v -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
 
-	# TODO(@SgtCoDFish): This is a temporary fix for an accidentally created nested crds directory
-	# in the PR: https://github.com/cert-manager/makefile-modules/pull/239
-	# Once this has been run on every repo with the mistaken folder, this can be removed
-	rm -r $(crds_dir)/crds
-
 	rm -rf $(crds_gen_temp)
 	mkdir -p $(crds_gen_temp)
 


### PR DESCRIPTION
This was intended to help clean up the extra CRDs dir which was created by mistake in https://github.com/cert-manager/makefile-modules/pull/239.

However, a different makefile-modules PR (https://github.com/cert-manager/makefile-modules/pull/240) meant that a manual upgrade was required for downstream repos using makefile-modules anyway.

As such, this is just error-prone and liable to break ci (it should've been `rm -rf` anyway).