### PR TITLE
Add ko --image-annotation and --image-label options

### DIFF
--- a/modules/oci-build/00_mod.mk
+++ b/modules/oci-build/00_mod.mk
@@ -43,6 +43,8 @@ go_$1_goexperiment ?= $(GOEXPERIMENT)
 go_$1_flags ?= -tags=
 oci_$1_additional_layers ?= 
 oci_$1_linux_capabilities ?= 
+oci_$1_image_annotation ?= 
+oci_$1_image_label ?= 
 endef
 
 $(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(build_name))))

--- a/modules/oci-build/01_mod.mk
+++ b/modules/oci-build/01_mod.mk
@@ -60,6 +60,8 @@ $(oci_build_targets): oci-build-%: ko-config-% | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS
 	LDFLAGS="$(go_$*_ldflags)" \
 	$(KO) build $(go_$*_mod_dir)/$(go_$*_main_dir) \
 		--platform=$(oci_platforms) \
+		--image-annotation=$(oci_$*_image_annotation) \
+		--image-label=$(oci_$*_image_label) \
 		--oci-layout-path=$(oci_layout_path_$*) \
 		--sbom-dir=$(CURDIR)/$(oci_layout_path_$*).sbom \
 		--sbom=spdx \

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -66,7 +66,7 @@ tools += kyverno=v1.12.5
 # https://github.com/mikefarah/yq/releases
 tools += yq=v4.44.3
 # https://github.com/ko-build/ko/releases
-tools += ko=0.16.0
+tools += ko=0.17.1
 # https://github.com/protocolbuffers/protobuf/releases
 tools += protoc=27.3
 # https://github.com/aquasecurity/trivy/releases
@@ -503,10 +503,10 @@ $(DOWNLOAD_DIR)/tools/yq@$(YQ_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR
 		$(checkhash_script) $(outfile) $(yq_$(HOST_OS)_$(HOST_ARCH)_SHA256SUM); \
 		chmod +x $(outfile)
 
-ko_linux_amd64_SHA256SUM=aee2caeced511e60c6889a4cfaf9ebe28ec35acb49531b7a90b09e0a963bcff7
-ko_linux_arm64_SHA256SUM=45b6ba20084b2199c63dcc738c54f7f6c37ea4e9c7f79eefc286d9947b11d0d1
-ko_darwin_amd64_SHA256SUM=5c98d0229fd2a82cc69510705b74a7196fc184641693930b0f9282b6d1f79d95
-ko_darwin_arm64_SHA256SUM=9c75b97f26ba98c62a86f3b39e2c74ced6c97092f301cd73fe4e5b3e16261698
+ko_linux_amd64_SHA256SUM=4f0b979b59880b3232f47d79c940f2279165aaad15a11d7614e8a2c9e5c78c29
+ko_linux_arm64_SHA256SUM=9421ebe2a611bac846844bd34fed5c75fba7b36c8cb1d113ad8680c48f6106df
+ko_darwin_amd64_SHA256SUM=888656c3f0028d4211654a9df57b003fe26f874b092776c83acace7aca8a73a4
+ko_darwin_arm64_SHA256SUM=d0b6bcc4f86c8d775688d1c21d416985ee557a85ad557c4a7d0e2d82b7cdbd92
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/ko@$(KO_VERSION)_$(HOST_OS)_$(HOST_ARCH)
 $(DOWNLOAD_DIR)/tools/ko@$(KO_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
This allows customisation of image annotations, e.g. for cert-manager's v1.17.0-beta.0 ppc64le image:

```console
$ crane config quay.io/jetstack/cert-manager-controller@sha256:d5d2305c3034c8d46ca275a67938a3d4448a768250ed92c631415c4cbe8fb1a8
{
  "architecture": "ppc64le",
  "config": {
    "User": "1000",
    "Env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ],
    "Entrypoint": [
      "/app/cmd/controller/controller"
    ],
    "WorkingDir": "/",
    "Labels": {
      "org.opencontainers.image.source": "https://github.com/cert-manager/cert-manager" <- this
    },
    "OnBuild": null
  },
  ...
}


```