### PR TITLE
BUGFIX: load Helm digest from file after writing it

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -80,7 +80,8 @@ helm-chart-oci-push: $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_CRANE)
 		| grep -o "sha256:.\+" \
 		| tee $(helm_digest_path)
 
-	$(CRANE) copy "$(helm_chart_image_name)@$(call helm_digest)" "$(helm_chart_image_name):$(helm_chart_image_tag:v%=%)"
+	helm_digest=$$(cat $(helm_digest_path)) && \
+	$(CRANE) copy "$(helm_chart_image_name)@$$helm_digest" "$(helm_chart_image_name):$(helm_chart_image_tag:v%=%)"
 
 .PHONY: helm-chart
 ## Create a helm chart


### PR DESCRIPTION
All makefile templating is done before running the bash script, resulting in the digest file being read before it was actually written to.
Now, we read the digest in the bash script itself, fixing the issue.

Bug was introduced in https://github.com/cert-manager/makefile-modules/pull/249