### PR TITLE
Use correct scratch directories and decouple modules

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -45,11 +45,14 @@ helm_chart_name := $(notdir $(helm_chart_image_name))
 helm_chart_image_registry := $(dir $(helm_chart_image_name))
 helm_chart_image_tag := $(helm_chart_version)
 helm_chart_sources := $(shell find $(helm_chart_source_dir) -maxdepth 1 -type f) $(shell find $(helm_chart_source_dir)/templates -type f)
-helm_chart_archive := $(bin_dir)/scratch/image/$(helm_chart_name)-$(helm_chart_version).tgz
-helm_digest_path := $(bin_dir)/scratch/image/$(helm_chart_name)-$(helm_chart_version).digests
+helm_chart_archive := $(bin_dir)/scratch/helm/$(helm_chart_name)-$(helm_chart_version).tgz
+helm_digest_path := $(bin_dir)/scratch/helm/$(helm_chart_name)-$(helm_chart_version).digests
 helm_digest = $(shell head -1 $(helm_digest_path) 2> /dev/null)
 
-$(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_dir)/scratch/image
+$(bin_dir)/scratch/helm:
+	@mkdir -p $@
+
+$(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_dir)/scratch/helm
 	$(eval helm_chart_source_dir_versioned := $@.tmp)
 	rm -rf $(helm_chart_source_dir_versioned)
 	mkdir -p $(dir $(helm_chart_source_dir_versioned))

--- a/modules/oci-build/01_mod.mk
+++ b/modules/oci-build/01_mod.mk
@@ -22,7 +22,10 @@ IMAGE_TOOL := $(CURDIR)/$(bin_dir)/tools/image_tool
 NEEDS_IMAGE_TOOL := $(bin_dir)/tools/image_tool
 $(NEEDS_IMAGE_TOOL): $(wildcard $(image_tool_dir)/*.go) | $(NEEDS_GO)
 	cd $(image_tool_dir) && GOWORK=off GOBIN=$(CURDIR)/$(dir $@) $(GO) install .
-	
+
+$(bin_dir)/scratch/image:
+	@mkdir -p $@
+
 define ko_config_target
 .PHONY: $(ko_config_path_$1:$(CURDIR)/%=%)
 $(ko_config_path_$1:$(CURDIR)/%=%): | $(NEEDS_YQ) $(bin_dir)/scratch/image

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -21,7 +21,7 @@ endif
 export DOWNLOAD_DIR ?= $(CURDIR)/$(bin_dir)/downloaded
 export GOVENDOR_DIR ?= $(CURDIR)/$(bin_dir)/go_vendor
 
-$(bin_dir)/scratch/image $(bin_dir)/tools $(DOWNLOAD_DIR)/tools:
+$(bin_dir)/tools $(DOWNLOAD_DIR)/tools:
 	@mkdir -p $@
 
 checkhash_script := $(dir $(lastword $(MAKEFILE_LIST)))/util/checkhash.sh


### PR DESCRIPTION
For some reason, the Helm module was using the `$(bin_dir)/scratch/image/` directory.
Additionally, `$(bin_dir)/scratch/image` was created by a target in the tools package.
This PR fixes those small issues.