### PR TITLE
Fix the verify-pod-security-standards target which was silently failing

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -64,7 +64,7 @@ $(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_d
 		echo "Chart name does not match the name in the helm_chart_name variable"; \
 		exit 1; \
 	fi
-	
+
 	$(YQ) '.annotations."artifacthub.io/prerelease" = "$(IS_PRERELEASE)"' \
 		--inplace $(helm_chart_source_dir_versioned)/Chart.yaml
 
@@ -81,7 +81,7 @@ $(helm_chart_archive): $(helm_chart_sources) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_d
 helm-chart-oci-push: $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_CRANE)
 	$(HELM) push "$(helm_chart_archive)" "oci://$(helm_chart_image_registry)" 2>&1 \
 		| tee >(grep -o "sha256:.\+" | tee $(helm_digest_path))
-	
+
 	@# $(helm_chart_image_tag:v%=%) removes the v prefix from the value stored in helm_chart_image_tag.
 	@# See https://www.gnu.org/software/make/manual/html_node/Substitution-Refs.html for the manual on the syntax.
 	helm_digest=$$(cat $(helm_digest_path)) && \
@@ -119,12 +119,34 @@ verify-helm-values: | $(NEEDS_HELM-TOOL) $(NEEDS_GOJQ)
 
 shared_verify_targets += verify-helm-values
 
+$(bin_dir)/scratch/kyverno:
+	@mkdir -p $@
+
+$(bin_dir)/scratch/kyverno/pod-security-policy.yaml: | $(NEEDS_KUSTOMIZE) $(bin_dir)/scratch/kyverno
+	@$(KUSTOMIZE) build https://github.com/kyverno/policies/pod-security/enforce > $@
+
+# Extra arguments for kyverno apply.
+kyverno_apply_extra_args :=
+# Allows known policy violations to be skipped by supplying Kyverno policy
+# exceptions.
+ifneq ("$(wildcard make/verify-pod-security-standards-exceptions.yaml)","")
+		kyverno_apply_extra_args += --exceptions make/verify-pod-security-standards-exceptions.yaml
+endif
+
 .PHONY: verify-pod-security-standards
 ## Verify that the Helm chart complies with the pod security standards.
+##
+## You can add Kyverno policy exceptions to
+## `make/verify-pod-security-standards-exceptions.yaml`, to skip some of the pod
+## security policy rules.
+##
 ## @category [shared] Generate/ Verify
-verify-pod-security-standards: $(helm_chart_archive) | $(NEEDS_KYVERNO) $(NEEDS_KUSTOMIZE) $(NEEDS_HELM)
-	$(KYVERNO) apply <($(KUSTOMIZE) build https://github.com/kyverno/policies/pod-security/enforce) \
-		--resource <($(HELM) template $(helm_chart_archive)) 2>/dev/null
+verify-pod-security-standards: $(helm_chart_archive) $(bin_dir)/scratch/kyverno/pod-security-policy.yaml | $(NEEDS_KYVERNO) $(NEEDS_HELM)
+	@$(HELM) template $(helm_chart_archive) $(INSTALL_OPTIONS) \
+	| $(KYVERNO) apply $(bin_dir)/scratch/kyverno/pod-security-policy.yaml \
+		$(kyverno_apply_extra_args) \
+		--resource - \
+		--table
 
 shared_verify_targets_dirty += verify-pod-security-standards
 


### PR DESCRIPTION
Merging this might cause the verify-pod-security-standards target to start failing in projects when they auto-upgrade. I've only checked it with Firefly MR: !479

There were multiple problems:

1. The INSTALL_OPTIONS were not being used So for charts with required options the `helm template` command was failing, but the make target exited with 0. E.g. in firefly

```
$ make verify-pod-security-standards
...
Error: execution error at (firefly/templates/NOTES.txt:8:4): please supply the clientID for your Venafi TLS Protect Cloud service account, by setting the Helm value `deployment.venafiClientID: <CLIENT_ID>` or by supplying the command line option `--set deployment.venafiClientID=<CLIENT_ID>`.

Use --debug flag to render out invalid YAML

Applying 0 policy rule(s) to 0 resource(s)...

pass: 0, fail: 0, warn: 0, error: 0, skip: 0

$ echo $?
0
```

2. `kyverno apply` was not reading the policy from the process substitution. The command was exiting with 0 as follows:

```
$ make verify-pod-security-standards
...
Applying 0 policy rule(s) to 16 resource(s)...

pass: 0, fail: 0, warn: 0, error: 0, skip: 0

$ echo $?
0
```

3. There was no way to provide exceptions, for when the deployment contains expected violations.