### PR TITLE
Make adding annotations and labels easier

### DIFF
--- a/modules/oci-build/00_mod.mk
+++ b/modules/oci-build/00_mod.mk
@@ -43,8 +43,7 @@ go_$1_goexperiment ?= $(GOEXPERIMENT)
 go_$1_flags ?= -tags=
 oci_$1_additional_layers ?= 
 oci_$1_linux_capabilities ?= 
-oci_$1_image_annotation ?= 
-oci_$1_image_label ?= 
+oci_$1_build_args ?= 
 endef
 
 $(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(build_name))))

--- a/modules/oci-build/01_mod.mk
+++ b/modules/oci-build/01_mod.mk
@@ -63,8 +63,7 @@ $(oci_build_targets): oci-build-%: ko-config-% | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS
 	LDFLAGS="$(go_$*_ldflags)" \
 	$(KO) build $(go_$*_mod_dir)/$(go_$*_main_dir) \
 		--platform=$(oci_platforms) \
-		--image-annotation=$(oci_$*_image_annotation) \
-		--image-label=$(oci_$*_image_label) \
+		$(oci_$*_build_args) \
 		--oci-layout-path=$(oci_layout_path_$*) \
 		--sbom-dir=$(CURDIR)/$(oci_layout_path_$*).sbom \
 		--sbom=spdx \


### PR DESCRIPTION
In https://github.com/cert-manager/makefile-modules/pull/246, we added the options to add annotations and labels on ko images.
However, the options are hard to use and read due to comma-separated values.
Instead, providing the flag multiple times is easier and allows for cleaner makefiles.

Before:
```
oci_image_image_label := "org.opencontainers.image.vendor"="Vendor","org.opencontainers.image.authors"="Author","org.opencontainers.image.title"="Title"
```

After:
```
oci_image_build_args := \
	--image-label="org.opencontainers.image.vendor"="Vendor" \
	--image-label="org.opencontainers.image.authors"="Author" \
	--image-label="org.opencontainers.image.title"="Title"
```