### PR TITLE
Change copy logic to fix macOS issues caused by 15.4

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -637,7 +637,7 @@ $(DOWNLOAD_DIR)/tools/preflight@$(PREFLIGHT_VERSION)_linux_$(HOST_ARCH): | $(DOW
 missing=$(shell (command -v curl >/dev/null || echo curl) \
              && (command -v sha256sum >/dev/null || command -v shasum >/dev/null || echo sha256sum) \
              && (command -v git >/dev/null || echo git) \
-             && (command -v rsync >/dev/null || echo rsync) \
+             && (command -v xargs >/dev/null || echo xargs) \
              && (command -v bash >/dev/null || echo bash))
 ifneq ($(missing),)
 $(error Missing required tools: $(missing))


### PR DESCRIPTION
macOS 15.4 changed rsync to point to a version of [openrsync](https://derflounder.wordpress.com/2025/04/06/rsync-replaced-with-openrsync-on-macos-sequoia/), which in turn seems to use different methods for opening files. rsync is currently used to copy files in "make verify" targets.

The change to openrsync causes issues on macOS 15.4 locally for me when copying git objects:

> `rsync(35586): error: .git/objects/<num>/<sha>: openat: Permission denied`

By changing away from rsync and using find instead, I can reliably run "make verify" locally and remove our dependency on rsync.