### PR TITLE
BUGFIX: don't copy the '.' folder

### DIFF
--- a/modules/generate-verify/util/verify.sh
+++ b/modules/generate-verify/util/verify.sh
@@ -53,7 +53,7 @@ trap "cleanup" EXIT SIGINT
 # 2. rsync on macOS 15.4 and newer is actually openrsync, which has different permissions and throws errors when copying git objects
 #
 # So, we use find to list all files except _bin, and then copy each in turn
-find . -maxdepth 1 -not \( -path "./_bin" -prune \) | xargs -I% cp -af "${projectdir}/%" "${tmp}/"
+find . -maxdepth 1 -not \( -path "./_bin" \) -not \( -path "." \) | xargs -I% cp -af "${projectdir}/%" "${tmp}/"
 
 pushd "${tmp}" >/dev/null
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/cert-manager/makefile-modules/pull/269.
We were also selecting the root directory (`.`) and copying that folder.

Old command:

```
find . -maxdepth 1 -not \( -path "./_bin" -prune \)
.
./.github
./modules
./tests
./OWNERS
./bootstrap.sh
./_upgrade
./scripts
./.git
./.gitignore
./LICENSE
./upgrade_all_repos.sh
./README.md
./Makefile
```

New command:

```
find . -maxdepth 1 -not \( -path "./_bin" \) -not \( -path "." \)
./.github
./modules
./tests
./OWNERS
./bootstrap.sh
./_upgrade
./scripts
./.git
./.gitignore
./LICENSE
./upgrade_all_repos.sh
./README.md
./Makefile
```

This likely caused https://github.com/cert-manager/makefile-modules/pull/269#issuecomment-2804844451
