### PR TITLE
Upgrade golangci-lint to v2.1.2 fixing bugs in protogetter linter

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -125,7 +125,7 @@ tools += cmctl=v2.1.1
 # https://pkg.go.dev/github.com/cert-manager/release/cmd/cmrel?tab=versions
 tools += cmrel=e3cbe5171488deda000145003e22567bdce622ea
 # https://pkg.go.dev/github.com/golangci/golangci-lint/v2/cmd/golangci-lint?tab=versions
-tools += golangci-lint=v2.1.1
+tools += golangci-lint=v2.1.2
 # https://pkg.go.dev/golang.org/x/vuln?tab=versions
 tools += govulncheck=v1.1.4
 # https://pkg.go.dev/github.com/operator-framework/operator-sdk/cmd/operator-sdk?tab=versions


### PR DESCRIPTION
Fixes the following error (see https://storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_istio-csr/530/pull-cert-manager-istio-csr-verify/1912676672981700608/build-log.txt):

```
Panic: protogetter: package \"mtls\" (isInitialPkg: true, needAnalyzeSource: true): runtime error: index out of range [5] with length 2: goroutine 45428
```