### PR TITLE
Add kubeconform verification of helm charts

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -178,3 +178,11 @@ verify-helm-lint: $(helm_chart_archive) | $(NEEDS_HELM)
 	$(HELM) lint $(helm_chart_archive)
 
 shared_verify_targets_dirty += verify-helm-lint
+
+.PHONY: verify-helm-kubeconform
+## Verify that the Helm chart passes a strict check using kubeconform
+## @category [shared] Generate/ Verify
+verify-helm-kubeconform: $(helm_chart_archive) | $(NEEDS_KUBECONFORM)
+	$(HELM) template kubeconform-template-do-not-use $< | $(KUBECONFORM) -strict
+
+shared_verify_targets_dirty += verify-helm-kubeconform

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -138,6 +138,8 @@ tools += preflight=1.12.1
 tools += gci=v0.13.6
 # https://github.com/google/yamlfmt/releases
 tools += yamlfmt=v0.16.0
+# https://github.com/yannh/kubeconform/releases
+tools += kubeconform=v0.6.7
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION := v0.32.3
@@ -345,6 +347,7 @@ go_dependencies += operator-sdk=github.com/operator-framework/operator-sdk/cmd/o
 go_dependencies += gh=github.com/cli/cli/v2/cmd/gh
 go_dependencies += gci=github.com/daixiang0/gci
 go_dependencies += yamlfmt=github.com/google/yamlfmt/cmd/yamlfmt
+go_dependencies += kubeconform=github.com/yannh/kubeconform/cmd/kubeconform
 
 #################
 # go build tags #


### PR DESCRIPTION
This catches the issue fixed by https://github.com/cert-manager/csi-driver-spiffe/pull/284 - so it's probably a useful thing to have in the Helm module, globally.