### PR TITLE
Use INSTALL_OPTIONS before kubeconform and add datreeio to kubeconform sources

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -183,6 +183,11 @@ shared_verify_targets_dirty += verify-helm-lint
 ## Verify that the Helm chart passes a strict check using kubeconform
 ## @category [shared] Generate/ Verify
 verify-helm-kubeconform: $(helm_chart_archive) | $(NEEDS_KUBECONFORM)
-	$(HELM) template kubeconform-template-do-not-use $< | $(KUBECONFORM) -strict
+	@$(HELM) template $(helm_chart_archive) $(INSTALL_OPTIONS) \
+	| $(KUBECONFORM) \
+		-schema-location default \
+		-schema-location "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json" \
+		-schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json" \
+		-strict
 
 shared_verify_targets_dirty += verify-helm-kubeconform


### PR DESCRIPTION
Should resolves some of the failures we are seeing (like https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_trust-manager/611/pull-trust-manager-verify/1915945738441854976).

The INSTALL_OPTIONS will make sure we are able to render the Helm chart (eg. when some of the values are required values).
By adding the datreeio source, we should be able to include cert-manager resources in our Helm charts.

This check was added here: https://github.com/cert-manager/makefile-modules/pull/280