### PR TITLE
kind image preload: simplify variables

### DIFF
--- a/modules/kind/kind-image-preload.mk
+++ b/modules/kind/kind-image-preload.mk
@@ -34,15 +34,13 @@ images_tar_dir := $(bin_dir)/downloaded/containers/$(IMAGE_ARCH)
 images_tars := $(foreach image,$(images),$(images_tar_dir)/$(subst :,+,$(image)).tar)
 
 # Download the images as tarballs. After downloading the image using
-# its digest, we untar the image and modify the .[0].RepoTags[0] value in
+# its digest, we use image-tool to modify the .[0].RepoTags[0] value in
 # the manifest.json file to have the correct tag (instead of "i-was-a-digest"
 # which is set when the image is pulled using its digest). This tag is used
 # to reference the image after it has been imported using docker or kind. Otherwise,
 # the image would be imported with the tag "i-was-a-digest" which is not very useful.
 # We would have to use digests to reference the image everywhere which might
 # not always be possible and does not match the default behavior of eg. our helm charts.
-# Untarring and modifying manifest.json is a hack and we hope that crane adds an option
-# in the future that allows setting the tag on images that are pulled by digest.
 # NOTE: the tag is fully determined based on the input, we fully allow the remote
 # tag to point to a different digest. This prevents CI from breaking due to upstream
 # changes. However, it also means that we can incorrectly combine digests with tags,

--- a/modules/kind/kind-image-preload.mk
+++ b/modules/kind/kind-image-preload.mk
@@ -26,10 +26,12 @@ endif
 
 ##########################################
 
-images := $(images_$(HOST_ARCH))
+IMAGE_ARCH ?= $(HOST_ARCH)
+
+images := $(images_$(IMAGE_ARCH))
 images_files := $(foreach image,$(images),$(subst :,+,$(image)))
 
-images_tar_dir := $(bin_dir)/downloaded/containers/$(HOST_ARCH)
+images_tar_dir := $(bin_dir)/downloaded/containers/$(IMAGE_ARCH)
 images_tars := $(images_files:%=$(images_tar_dir)/%.tar)
 
 # Download the images as tarballs. After downloading the image using
@@ -52,7 +54,7 @@ $(images_tars): $(images_tar_dir)/%.tar: | $(NEEDS_IMAGE-TOOL) $(NEEDS_CRANE) $(
 	@$(eval digest=$(word 2,$(subst @, ,$(full_image))))
 	@$(eval tag=$(word 2,$(subst :, ,$(word 1,$(subst @, ,$(full_image))))))
 	@mkdir -p $(dir $@)
-	$(CRANE) pull "$(bare_image)@$(digest)" $@ --platform=linux/$(HOST_ARCH)
+	$(CRANE) pull "$(bare_image)@$(digest)" $@ --platform=linux/$(IMAGE_ARCH)
 	$(IMAGE-TOOL) tag-docker-tar $@ "$(bare_image):$(tag)"
 
 images_tar_envs := $(images_files:%=env-%)


### PR DESCRIPTION
Make TAR, REPO, TAG and FULL variables directly available (no longer require depending on the `env-...` target).
I found this simplification while working on making cert-manager/cert-manager use more makefile modules.