### PR TITLE
Make Kubernetes version used by Kind configurable using K8S_VERSION

### DIFF
--- a/modules/kind/00_mod.mk
+++ b/modules/kind/00_mod.mk
@@ -17,5 +17,17 @@ include $(dir $(lastword $(MAKEFILE_LIST)))/00_kind_image_versions.mk
 images_amd64 ?=
 images_arm64 ?=
 
+# K8S_VERSION can be used to specify a specific
+# kubernetes version to use with Kind.
+K8S_VERSION ?=
+ifeq ($(K8S_VERSION),)
 images_amd64 += $(kind_image_latest_amd64)
 images_arm64 += $(kind_image_latest_arm64)
+else
+fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))
+$(call fatal_if_undefined,kind_image_kube_$(K8S_VERSION)_amd64)
+$(call fatal_if_undefined,kind_image_kube_$(K8S_VERSION)_arm64)
+
+images_amd64 += $(kind_image_kube_$(K8S_VERSION)_amd64)
+images_arm64 += $(kind_image_kube_$(K8S_VERSION)_arm64)
+endif


### PR DESCRIPTION
Allow specifying a custom Kubernetes version.
Useful for testing the controller with specific Kubernetes versions.