### PR TITLE
Fix location of licenses template

### DIFF
--- a/modules/licenses/01_mod.mk
+++ b/modules/licenses/01_mod.mk
@@ -14,6 +14,9 @@
 
 ###################### Generate LICENSES files ######################
 
+# _module_dir is the directory containing this Makefile, used to retrieve the path of the licenses.tmpl file
+_module_dir := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 # Create a go.work file so that go-licenses can discover the LICENSE file of the
 # other modules in the repo.
 #
@@ -30,11 +33,11 @@ generate-go-licenses: #
 shared_generate_targets += generate-go-licenses
 
 define licenses_target
-$1/LICENSES: $1/go.mod $(licenses_go_work) $(dir $(lastword $(MAKEFILE_LIST)))/licenses.tmpl | $(NEEDS_GO-LICENSES)
+$1/LICENSES: $1/go.mod $(licenses_go_work) $(_module_dir)/licenses.tmpl | $(NEEDS_GO-LICENSES)
 	cd $$(dir $$@) && \
 		GOWORK=$(abspath $(licenses_go_work)) \
 		GOOS=linux GOARCH=amd64 \
-		$(GO-LICENSES) report --ignore "$$(license_ignore)" --template $(dir $(lastword $(MAKEFILE_LIST)))/licenses.tmpl ./... > LICENSES
+		$(GO-LICENSES) report --ignore "$$(license_ignore)" --template $(_module_dir)/licenses.tmpl ./... > LICENSES
 
 generate-go-licenses: $1/LICENSES
 # The /LICENSE targets make sure these files exist.


### PR DESCRIPTION
Fixes an issue in #300 when there are nested go.mod files within a repo.

I was a little wary of referring to `make/_shared` here but it's already referred to here: https://github.com/cert-manager/makefile-modules/blob/7085ba6f6b6c97fcd0062b692ac71513f6908c4c/modules/go/01_mod.mk#L33