### PR TITLE
Fix category name for licenses module

### DIFF
--- a/modules/licenses/01_mod.mk
+++ b/modules/licenses/01_mod.mk
@@ -28,7 +28,7 @@ $(licenses_go_work): $(bin_dir)/scratch
 		$(MAKE) go-workspace
 
 ## Generate licenses for the golang dependencies
-## @category [shared] Generate/Verify
+## @category [shared] Generate/ Verify
 generate-go-licenses: #
 shared_generate_targets += generate-go-licenses
 


### PR DESCRIPTION
Before this change:

```console
$ make help
...
[shared] Generate/Verify
    generate-go-licenses          > Generate licenses for the golang dependencies

[shared] Generate/ Verify
    verify                        > Verify code and generate targets.
    verify-pod-security-standards > Verify that the Helm chart complies with the pod security standards.
...
```

After this change:

```console
$ make help
...
[shared] Generate/ Verify
    verify                        > Verify code and generate targets.
    verify-pod-security-standards > Verify that the Helm chart complies with the pod security standards.

                                    You can add Kyverno policy exceptions to
                                    `make/verify-pod-security-standards-exceptions.yaml`, to skip some of the pod
                                    security policy rules.
...
    generate-go-licenses          > Generate licenses for the golang dependencies
...
```