### PR TITLE
Bump tools versions to their latest releases

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -61,97 +61,97 @@ NEEDS_CTR = __require-ctr
 
 tools :=
 # https://github.com/helm/helm/releases
-tools += helm=v3.17.2
+tools += helm=v3.18.3
 # https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
-tools += kubectl=v1.32.3
+tools += kubectl=v1.33.2
 # https://github.com/kubernetes-sigs/kind/releases
 tools += kind=v0.29.0
 # https://www.vaultproject.io/downloads
-tools += vault=1.19.1
+tools += vault=1.20.0
 # https://github.com/Azure/azure-workload-identity/releases
-tools += azwi=v1.4.1
+tools += azwi=v1.5.1
 # https://github.com/kyverno/kyverno/releases
-tools += kyverno=v1.13.4
+tools += kyverno=v1.14.4
 # https://github.com/mikefarah/yq/releases
-tools += yq=v4.45.1
+tools += yq=v4.45.4
 # https://github.com/ko-build/ko/releases
-tools += ko=0.17.1
+tools += ko=0.18.0
 # https://github.com/protocolbuffers/protobuf/releases
-tools += protoc=30.2
+tools += protoc=31.1
 # https://github.com/aquasecurity/trivy/releases
-tools += trivy=v0.61.0
+tools += trivy=v0.64.1
 # https://github.com/vmware-tanzu/carvel-ytt/releases
-tools += ytt=v0.51.2
+tools += ytt=v0.52.0
 # https://github.com/rclone/rclone/releases
-tools += rclone=v1.69.1
+tools += rclone=v1.70.2
 # https://github.com/istio/istio/releases
-tools += istioctl=1.25.1
+tools += istioctl=1.26.2
 
 ### go packages
 # https://pkg.go.dev/sigs.k8s.io/controller-tools/cmd/controller-gen?tab=versions
-tools += controller-gen=v0.17.3
+tools += controller-gen=v0.18.0
 # https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=versions
-tools += goimports=v0.31.0
+tools += goimports=v0.34.0
 # https://pkg.go.dev/github.com/google/go-licenses/v2?tab=versions
 tools += go-licenses=8c3708dd545a9faed3777bf50a3530ff8082180a
 # https://pkg.go.dev/gotest.tools/gotestsum?tab=versions
-tools += gotestsum=v1.12.1
-# https://pkg.go.dev/sigs.k8s.io/kustomize/kustomize/v4?tab=versions
-tools += kustomize=v4.5.7
+tools += gotestsum=v1.12.3
+# https://pkg.go.dev/sigs.k8s.io/kustomize/kustomize/v5?tab=versions
+tools += kustomize=v5.7.0
 # https://pkg.go.dev/github.com/itchyny/gojq?tab=versions
 tools += gojq=v0.12.17
 # https://pkg.go.dev/github.com/google/go-containerregistry/pkg/crane?tab=versions
-tools += crane=v0.20.3
+tools += crane=v0.20.6
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions
 tools += protoc-gen-go=v1.36.6
 # https://pkg.go.dev/github.com/sigstore/cosign/v2/cmd/cosign?tab=versions
-tools += cosign=v2.4.3
+tools += cosign=v2.5.2
 # https://pkg.go.dev/github.com/cert-manager/boilersuite?tab=versions
 tools += boilersuite=v0.1.0
 # https://pkg.go.dev/github.com/princjef/gomarkdoc/cmd/gomarkdoc?tab=versions
 tools += gomarkdoc=v1.1.0
 # https://pkg.go.dev/oras.land/oras/cmd/oras?tab=versions
-tools += oras=v1.2.2
+tools += oras=v1.2.3
 # https://pkg.go.dev/github.com/onsi/ginkgo/v2/ginkgo?tab=versions
 # The gingko version should be kept in sync with the version used in code.
 # If there is no go.mod file (which is only the case for the makefile-modules
 # repo), then we default to a version that we know exists. We have to do this
 # because otherwise the awk failure renders the whole makefile unusable.
-detected_ginkgo_version := $(shell [[ -f go.mod ]] && awk '/ginkgo\/v2/ {print $$2}' go.mod || echo "v2.13.2")
+detected_ginkgo_version := $(shell [[ -f go.mod ]] && awk '/ginkgo\/v2/ {print $$2}' go.mod || echo "v2.23.4")
 tools += ginkgo=$(detected_ginkgo_version)
 # https://pkg.go.dev/github.com/cert-manager/klone?tab=versions
 tools += klone=v0.2.0
 # https://pkg.go.dev/github.com/goreleaser/goreleaser?tab=versions
 tools += goreleaser=v1.26.2
 # https://pkg.go.dev/github.com/anchore/syft/cmd/syft?tab=versions
-tools += syft=v1.22.0
+tools += syft=v1.28.0
 # https://github.com/cert-manager/helm-tool/releases
 tools += helm-tool=v0.5.3
 # https://github.com/cert-manager/image-tool/releases
-tools += image-tool=v0.0.2
+tools += image-tool=v0.1.0
 # https://github.com/cert-manager/cmctl/releases
-tools += cmctl=v2.1.1
+tools += cmctl=v2.2.0
 # https://pkg.go.dev/github.com/cert-manager/release/cmd/cmrel?tab=versions
 tools += cmrel=e3cbe5171488deda000145003e22567bdce622ea
 # https://pkg.go.dev/github.com/golangci/golangci-lint/v2/cmd/golangci-lint?tab=versions
-tools += golangci-lint=v2.1.2
+tools += golangci-lint=v2.2.1
 # https://pkg.go.dev/golang.org/x/vuln?tab=versions
 tools += govulncheck=v1.1.4
 # https://pkg.go.dev/github.com/operator-framework/operator-sdk/cmd/operator-sdk?tab=versions
-tools += operator-sdk=v1.39.2
+tools += operator-sdk=v1.40.0
 # https://pkg.go.dev/github.com/cli/cli/v2?tab=versions
-tools += gh=v2.69.0
+tools += gh=v2.74.2
 # https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases
-tools += preflight=1.12.1
+tools += preflight=1.14.0
 # https://github.com/daixiang0/gci/releases
 tools += gci=v0.13.6
 # https://github.com/google/yamlfmt/releases
-tools += yamlfmt=v0.16.0
+tools += yamlfmt=v0.17.2
 # https://github.com/yannh/kubeconform/releases
-tools += kubeconform=v0.6.7
+tools += kubeconform=v0.7.0
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
-K8S_CODEGEN_VERSION := v0.32.3
+K8S_CODEGEN_VERSION := v0.33.2
 tools += client-gen=$(K8S_CODEGEN_VERSION)
 tools += deepcopy-gen=$(K8S_CODEGEN_VERSION)
 tools += informer-gen=$(K8S_CODEGEN_VERSION)
@@ -160,10 +160,10 @@ tools += applyconfiguration-gen=$(K8S_CODEGEN_VERSION)
 tools += defaulter-gen=$(K8S_CODEGEN_VERSION)
 tools += conversion-gen=$(K8S_CODEGEN_VERSION)
 # https://github.com/kubernetes/kube-openapi
-tools += openapi-gen=c8a335a9a2ffc5aff16dfef74896a1ee34eb235d
+tools += openapi-gen=9bd5c66d9911c53f5aedb8595fde9c229ca56703
 
 # https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/envtest-releases.yaml
-KUBEBUILDER_ASSETS_VERSION := v1.32.0
+KUBEBUILDER_ASSETS_VERSION := v1.33.0
 tools += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 tools += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
@@ -329,7 +329,7 @@ go_dependencies += goimports=golang.org/x/tools/cmd/goimports
 # https://github.com/google/go-licenses/pull/327 is merged.
 go_dependencies += go-licenses=github.com/inteon/go-licenses/v2
 go_dependencies += gotestsum=gotest.tools/gotestsum
-go_dependencies += kustomize=sigs.k8s.io/kustomize/kustomize/v4
+go_dependencies += kustomize=sigs.k8s.io/kustomize/kustomize/v5
 go_dependencies += gojq=github.com/itchyny/gojq/cmd/gojq
 go_dependencies += crane=github.com/google/go-containerregistry/cmd/crane
 go_dependencies += protoc-gen-go=google.golang.org/protobuf/cmd/protoc-gen-go
@@ -493,7 +493,7 @@ $(DOWNLOAD_DIR)/tools/kube-apiserver@$(KUBEBUILDER_ASSETS_VERSION)_$(HOST_OS)_$(
 kyverno_linux_amd64_SHA256SUM=abd318dbb971ab6de2bbe3b7226f4a03230d5c9c651df8a29b6b5e085a55aeeb
 kyverno_linux_arm64_SHA256SUM=33ccb628b939f075bb8b7f35f5c6ce672cb6733d5748f4df196fa0ce1c67b4d2
 kyverno_darwin_amd64_SHA256SUM=ade0f72c5e93a906396b82f2007226b507d2ff1e06e6b548756ec62a86efc941
-kyverno_darwin_arm64_SHA256SUM=af61da03d44c4e213e05c11981e80b511725c65911a09dc12f0371e06d190766
+kyverno_darwin_arm64_SHA256SUM=4eb55cfbf1e9b5f63b24cac93932b607f01a399333f2caefe37f6222c52d11c2
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/kyverno@$(KYVERNO_VERSION)_$(HOST_OS)_$(HOST_ARCH)
 $(DOWNLOAD_DIR)/tools/kyverno@$(KYVERNO_VERSION)_$(HOST_OS)_$(HOST_ARCH): | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
Some of our versions were a bit outdated, but in general, this PR includes patch updates to tools. I bumped kustomize to v5, as the latest v4 release is from 2022. 😉 