### PR TITLE
Upgrade goreleaser to v2

### DIFF
--- a/modules/executable/01_mod.mk
+++ b/modules/executable/01_mod.mk
@@ -57,7 +57,7 @@ define template_for_target
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .ldflags[0] = "-s")' | \
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .ldflags[1] = "-w")' | \
 	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .ldflags[2] = "$(go_$1_ldflags)")' | \
-	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .gobinary = "$(GO)")' | \
+	$(YQ) 'with(.builds[]; select(.id == "$(1)") | .tool = "$(GO)")' | \
 	targets=$(exe_targets) $(YQ) 'with(.builds[]; select(.id == "$(1)") | .targets = (env(targets) | split(",")))' |
 endef
 

--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -121,8 +121,8 @@ detected_ginkgo_version := $(shell [[ -f go.mod ]] && awk '/ginkgo\/v2/ {print $
 tools += ginkgo=$(detected_ginkgo_version)
 # https://pkg.go.dev/github.com/cert-manager/klone?tab=versions
 tools += klone=v0.2.0
-# https://pkg.go.dev/github.com/goreleaser/goreleaser?tab=versions
-tools += goreleaser=v1.26.2
+# https://pkg.go.dev/github.com/goreleaser/goreleaser/v2?tab=versions
+tools += goreleaser=v2.11.0
 # https://pkg.go.dev/github.com/anchore/syft/cmd/syft?tab=versions
 tools += syft=v1.28.0
 # https://github.com/cert-manager/helm-tool/releases
@@ -338,7 +338,7 @@ go_dependencies += boilersuite=github.com/cert-manager/boilersuite
 go_dependencies += gomarkdoc=github.com/princjef/gomarkdoc/cmd/gomarkdoc
 go_dependencies += oras=oras.land/oras/cmd/oras
 go_dependencies += klone=github.com/cert-manager/klone
-go_dependencies += goreleaser=github.com/goreleaser/goreleaser
+go_dependencies += goreleaser=github.com/goreleaser/goreleaser/v2
 go_dependencies += syft=github.com/anchore/syft/cmd/syft
 go_dependencies += client-gen=k8s.io/code-generator/cmd/client-gen
 go_dependencies += deepcopy-gen=k8s.io/code-generator/cmd/deepcopy-gen


### PR DESCRIPTION
We're using a really old version of goreleaser and I hope that updating to the latest version will fix the following problems that I'm noticing with the gitlab releases for some internal CA projects:
 * Broken links to release artifacts. All the goreleaser release artifacts result in a 404 error wen clicked.
 * Creates release notes relative to previous pre-release versions rather than relative to the last minor or patch version.
 * When two tags reference the same commit, goreleaser was using the semantically lower tag and failing. For example with v1.21.0-alpha.1 and v1.21.0, because it had already created release artifacts for the alpha release and was trying to create the same release again rather than v1.21.0

https://github.com/goreleaser/goreleaser/releases/tag/v2.11.0

## Testing

In https://github.com/cert-manager/cmctl/pull/247 I created a test release:
 * Tag: https://github.com/cert-manager/cmctl/releases/tag/v2.3.0-alpha.1
 * Build: https://github.com/cert-manager/cmctl/actions/runs/16198123348

I tested the resulting cmctl binary as follows:

```bash
curl -fsSL -O https://github.com/cert-manager/cmctl/releases/download/v2.3.0-alpha.1/cmctl_linux_amd64
chmod +x cmctl_linux_amd64
mv cmctl_linux_amd64 ~/.local/bin/
kind create cluster
cmctl x install
cmctl version -o yaml
```

```
clientVersion:
  compiler: gc
  gitCommit: 262bd50637c41abdf37bf3821472a62f318f225f
  gitTreeState: ""
  gitVersion: v2.3.0-alpha.1
  goVersion: go1.24.5
  platform: linux/amd64
serverVersion:
  detected: v1.18.2
  sources:
    crdLabelVersion: v1.18.2
```