### PR TITLE
Add generate-applyconfigurations target to controller-gen module

### DIFF
--- a/modules/controller-gen/01_mod.mk
+++ b/modules/controller-gen/01_mod.mk
@@ -12,23 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-################
-# Check Inputs #
-################
-
 ifndef go_header_file
 $(error go_header_file is not set)
 endif
 
-################
-# Add targets #
-################
+controller_gen_sources = $(shell ls -d */ | grep -v '_bin' | grep -v 'make')
 
 .PHONY: generate-deepcopy
 ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 ## @category [shared] Generate/ Verify
 generate-deepcopy: | $(NEEDS_CONTROLLER-GEN)
-	$(eval directories := $(shell ls -d */ | grep -v '_bin' | grep -v 'make'))
-	$(CONTROLLER-GEN) object:headerFile=$(go_header_file) $(directories:%=paths=./%...)
+	$(CONTROLLER-GEN) object:headerFile=$(go_header_file) $(controller_gen_sources:%=paths=./%...)
 
 shared_generate_targets += generate-deepcopy
+
+.PHONY: generate-applyconfigurations
+## Generate applyconfigurations to support typesafe SSA.
+## @category [shared] Generate/ Verify
+generate-applyconfigurations: | $(NEEDS_CONTROLLER-GEN)
+	$(CONTROLLER-GEN) applyconfiguration:headerFile=$(go_header_file) $(controller_gen_sources:%=paths=./%...)
+
+shared_generate_targets += generate-applyconfigurations


### PR DESCRIPTION
Follow-up to https://github.com/cert-manager/trust-manager/pull/657. By adding this new target to the shared targets, we can easily enable the generation of applyconfigurations in any of our controller projects just by adding markers.

~Also removing the applyconfiguration-gen tool configuration as there should be no need to use applyconfiguration-gen directly after this PR.~ UPDATE: After creating https://github.com/cert-manager/cert-manager/pull/7866, I think we should still keep the applyconfiguration-gen tool.