### PR TITLE
Allow for excluding CRD template files

### DIFF
--- a/modules/helm/crds.mk
+++ b/modules/helm/crds.mk
@@ -40,6 +40,15 @@ endif
 crds_dir ?= deploy/crds
 crds_dir_readme := $(dir $(lastword $(MAKEFILE_LIST)))/crds_dir.README.md
 crds_expression ?= .Values.crds.enabled
+crds_template_include_pattern := *.yaml
+# Space-separated list of basenames to exclude (e.g. foo.yaml *_test.yaml)
+crds_template_exclude_pattern ?=
+
+define filter-out-basenames
+  $(if $(strip $(2)), \
+    $(foreach f,$(1),$(if $(filter $(2),$(notdir $(f))),,$(f))), \
+    $(1))
+endef
 
 .PHONY: generate-crds
 ## Generate CRD manifests.
@@ -57,14 +66,20 @@ generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
 
 	@echo "Updating CRDs with helm templating, writing to $(helm_chart_source_dir)/templates"
 
-	@for i in $$(ls $(crds_gen_temp)); do \
-		crd_name=$$($(YQ) eval '.metadata.name' $(crds_gen_temp)/$$i); \
-		cat $(crd_template_header) > $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(sed_inplace) "s/REPLACE_CRD_EXPRESSION/$(crds_expression)/g" $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(sed_inplace) "s/REPLACE_CRD_NAME/$$crd_name/g" $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(sed_inplace) "s/REPLACE_LABELS_TEMPLATE/$(helm_labels_template_name)/g" $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(YQ) -I2 '{"spec": .spec}' $(crds_gen_temp)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
-		cat $(crd_template_footer) >> $(helm_chart_source_dir)/templates/crd-$$i; \
+	$(eval crds_gen_temp_all_files := $(wildcard $(crds_gen_temp)/$(crds_template_include_pattern)))
+	$(eval crds_gen_temp_files := $(if $(crds_template_exclude_pattern), \
+		$(call filter-out-basenames,$(crds_gen_temp_all_files),$(crds_template_exclude_pattern)), \
+		$(crds_gen_temp_all_files)))
+
+	@for f in $(crds_gen_temp_files); do \
+		crd_name=$$($(YQ) eval '.metadata.name' $$f); \
+		crd_template_file="$(helm_chart_source_dir)/templates/crd-$$(basename $$f)"; \
+		cat $(crd_template_header) > $$crd_template_file; \
+		$(sed_inplace) "s/REPLACE_CRD_EXPRESSION/$(crds_expression)/g" $$crd_template_file; \
+		$(sed_inplace) "s/REPLACE_CRD_NAME/$$crd_name/g" $$crd_template_file; \
+		$(sed_inplace) "s/REPLACE_LABELS_TEMPLATE/$(helm_labels_template_name)/g" $$crd_template_file; \
+		$(YQ) -I2 '{"spec": .spec}' $$f >> $$crd_template_file; \
+		cat $(crd_template_footer) >> $$crd_template_file; \
 	done
 
 	@if [ -n "$$(ls $(crds_gen_temp) 2>/dev/null)" ]; then \


### PR DESCRIPTION
This adds a new feature to the Helm module, allowing exclusion of CRD(s) from getting included into the Helm chart. This feature is needed to avoid introducing the `ClusterBundle` API prematurely in trust-manger, ref. https://github.com/cert-manager/trust-manager/pull/662.

Generating the CRD will allow me to start working on validation, including tests, for the new API. But at the same time, avoiding the new CRD from being available to users.