### PR TITLE
Simplify GCI golangci-lint config with localmodule

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -72,7 +72,7 @@ formatters:
       sections:
         - standard # Standard section: captures all standard packages.
         - default # Default section: contains all imports that could not be matched to another section type.
-        - prefix({{REPO-NAME}}) # Custom section: groups all imports with the specified Prefix.
+        - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
         - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
         - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
   exclusions:

--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -16,10 +16,6 @@ ifndef bin_dir
 $(error bin_dir is not set)
 endif
 
-ifndef repo_name
-$(error repo_name is not set)
-endif
-
 golangci_lint_override := $(dir $(lastword $(MAKEFILE_LIST)))/.golangci.override.yaml
 
 .PHONY: go-workspace
@@ -110,7 +106,6 @@ generate-golangci-lint-config: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/s
 	cp $(golangci_lint_config) $(bin_dir)/scratch/golangci-lint.yaml.tmp
 	$(YQ) -i 'del(.linters.enable)' $(bin_dir)/scratch/golangci-lint.yaml.tmp
 	$(YQ) eval-all -i '. as $$item ireduce ({}; . * $$item)' $(bin_dir)/scratch/golangci-lint.yaml.tmp $(golangci_lint_override)
-	$(YQ) -i '(.. | select(tag == "!!str")) |= sub("{{REPO-NAME}}", "$(repo_name)")' $(bin_dir)/scratch/golangci-lint.yaml.tmp
 	mv $(bin_dir)/scratch/golangci-lint.yaml.tmp $(golangci_lint_config)
 
 shared_generate_targets += generate-golangci-lint-config


### PR DESCRIPTION
This PR simplifies the golangci-lint override config by taking advantage of a relatively new (last year) feature in the GCI linter: `localmodule`, avoiding the complex yq template syntax currently used.