### PR TITLE
Allow custom orgs for running govulncheck jobs

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -63,11 +63,16 @@ default_govulncheck_generate_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/bas
 # pipeline (eg. a GitLab pipeline).
 govulncheck_generate_base_dir ?= $(default_govulncheck_generate_base_dir)
 
+# The org name used in the govulncheck GH action. This is used to prevent the govulncheck job
+# being run on every fork of the repo.
+govulncheck_generate_org ?= cert-manager
+
 .PHONY: generate-govulncheck
 ## Generate base files in the repository
 ## @category [shared] Generate/ Verify
 generate-govulncheck:
-	cp -r $(govulncheck_generate_base_dir)/. ./
+	@mkdir -p ./.github/workflows
+	sed 's/ORGNAMEHERE/$(govulncheck_generate_org)/g' $(govulncheck_generate_base_dir)/.github/workflows/govulncheck.yaml > .github/workflows/govulncheck.yaml
 
 shared_generate_targets += generate-govulncheck
 

--- a/modules/go/base/.github/workflows/govulncheck.yaml
+++ b/modules/go/base/.github/workflows/govulncheck.yaml
@@ -17,7 +17,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == 'cert-manager'
+    if: github.repository_owner == 'ORGNAMEHERE'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Repos outside the cert-manager org might want to use the govulncheck job; this could be other repos depending on makefile-modules, or forks of cert-manager org repos who want to run the job.

By setting `govulncheck_generate_org` in `make/00_mod.mk` users of makefile-modules will be able to use a custom org.

This does also change the `generate-govulncheck` job to only copy the govulncheck workflow file, rather than copying the whole `modules/go/base` directory, but the govulncheck file was the only one in that repo anyway (and it would be confusing to copy other files in a target called `generate-govulncheck`)

## Testing

I've tested this with a local copy of trust-manager pointing at this branch and it worked as expected. Diff:

```diff
diff --git i/.github/workflows/govulncheck.yaml w/.github/workflows/govulncheck.yaml
index 25018fe..7eeeff9 100644
--- i/.github/workflows/govulncheck.yaml
+++ w/.github/workflows/govulncheck.yaml
@@ -17,7 +17,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == 'cert-manager'
+    if: github.repository_owner == 'foobar'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
diff --git i/make/00_mod.mk w/make/00_mod.mk
index 0da7d33..0024cdd 100644
--- i/make/00_mod.mk
+++ w/make/00_mod.mk
@@ -66,6 +66,8 @@ helm_labels_template_name := trust-manager.labels
 
 golangci_lint_config := .golangci.yaml
 
+govulncheck_generate_org := foobar
+
 define helm_values_mutation_function
 $(YQ) \
 	'( .image.repository = "$(oci_manager_image_name)" ) | \
```