### PR TITLE
Add GOPRIVATE option for govulncheck

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -58,6 +58,7 @@ generate-go-mod-tidy: | $(NEEDS_GO)
 shared_generate_targets += generate-go-mod-tidy
 
 default_govulncheck_generate_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
+
 # The base directory used to copy the govulncheck GH action from. This can be
 # overwritten with an action with extra authentication or with a totally different
 # pipeline (eg. a GitLab pipeline).
@@ -66,6 +67,10 @@ govulncheck_generate_base_dir ?= $(default_govulncheck_generate_base_dir)
 # The org name used in the govulncheck GH action. This is used to prevent the govulncheck job
 # being run on every fork of the repo.
 govulncheck_generate_org ?= cert-manager
+
+# Any closed-source or inaccessible Go modules that should be ignored by govulncheck; not needed
+# for most open-source projects.
+govulncheck_goprivate ?=
 
 .PHONY: generate-govulncheck
 ## Generate base files in the repository
@@ -96,7 +101,7 @@ verify-govulncheck: | $(NEEDS_GOVULNCHECK)
 				target=$$(dirname $${d}); \
 				echo "Running 'GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(bin_dir)/tools/govulncheck ./...' in directory '$${target}'"; \
 				pushd "$${target}" >/dev/null; \
-				GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(GOVULNCHECK) ./... || exit; \
+				GOPRIVATE=$(govulncheck_goprivate) GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(GOVULNCHECK) ./... || exit; \
 				popd >/dev/null; \
 				echo ""; \
 			done


### PR DESCRIPTION
Full disclosure: this change is for a non-cert-manager repo. It should have no impact on any cert-manager stuff, but it'll make our go makefile-module a little easier to use elsewhere.

Simply adds the ability to specify GOPRIVATE for govulncheck.

I've tested that this allows a job to run with a private dependency: https://github.com/jetstack/jetstack-secure/actions/runs/16752151437

Example of what a run without this change looks like for that repo: https://github.com/jetstack/jetstack-secure/actions/runs/16751722851/job/47423444330