### PR TITLE
Revert #315, add skip for govulncheck

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -57,6 +57,8 @@ generate-go-mod-tidy: | $(NEEDS_GO)
 
 shared_generate_targets += generate-go-mod-tidy
 
+ifndef govulncheck_skip
+
 default_govulncheck_generate_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
 # The base directory used to copy the govulncheck GH action from. This can be
 # overwritten with an action with extra authentication or with a totally different
@@ -100,6 +102,8 @@ verify-govulncheck: | $(NEEDS_GOVULNCHECK)
 				popd >/dev/null; \
 				echo ""; \
 			done
+
+endif # govulncheck_skip
 
 ifdef golangci_lint_config
 


### PR DESCRIPTION
I'd mistakenly thought that govulncheck respected GOPRIVATE from local testing, but I'd actually set up an environment where govulncheck had access to the private dependency I was trying to avoid and as such it had passed locally and started to fail in CI.

Now that I know that, the content of #315 is pointless and can be reverted. This PR instead adds the options to opt-out of govulncheck from the `go` module. This is obviously a bad idea in most cases because govulncheck is great, but it allows makefile-modules users to provide their own govulncheck YAML and not get errors from `make verify` or get their YAML overwritten by `make generate`