### PR TITLE
Improve error message for helm chart version

### DIFF
--- a/modules/helm/helm.mk
+++ b/modules/helm/helm.mk
@@ -32,7 +32,7 @@ ifndef helm_chart_version
 $(error helm_chart_version is not set)
 endif
 ifneq ($(helm_chart_version:v%=v),v)
-$(error helm_chart_version "$(helm_chart_version)" should start with a "v")
+$(error helm_chart_version "$(helm_chart_version)" should start with a "v" - did you forget to pull tags from the remote repository?)
 endif
 
 ifndef helm_values_mutation_function


### PR DESCRIPTION
The following error is common if a repo does not locally contain any tags:

```console
$ make test-e2e
make/_shared/helm///helm.mk:35: *** helm_chart_version "aaaaaaaaaaaaaa-dirty" should start with a "v".  Stop.
```

This is because makefile-modules uses tag-based logic to determine the chart version. Without tags, it defaults to a hash which fails the check edited by this commit.

This commit adds a hint about pulling remote tags to help users diagnose this issue and fix it.

---

I tested this locally and it produced the error as expected (I was just checking for like syntax errors or something like that):

```console
$ make test-e2e
make/_shared/helm///helm.mk:35: *** helm_chart_version "47dac174b6f5c3-dirty" should start with a "v" - did you forget to pull tags from the remote repository?.  Stop.
```