### PR TITLE
Set PS1="" to prevent "/etc/bash.bashrc: line 7: PS1: unbound variable\n/etc/bash.bashrc" warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@
 
 ###################################################################################
 
-# Some modules build their dependencies from variables, we want these to be
-# evaluated at the last possible moment. For this we use second expansion to
+# Some modules build their dependencies from variables, we want these to be 
+# evaluated at the last possible moment. For this we use second expansion to 
 # re-evaluate the generate and verify targets a second time.
 #
 # See https://www.gnu.org/software/make/manual/html_node/Secondary-Expansion.html
@@ -31,7 +31,7 @@
 # For details on some of these "prelude" settings, see:
 # https://clarkgrubb.com/makefile-style-guide
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
-SHELL := /usr/bin/env bash
+SHELL := /usr/bin/env PS1="" bash
 .SHELLFLAGS := -uo pipefail -c
 .DEFAULT_GOAL := help
 .DELETE_ON_ERROR:

--- a/modules/repository-base/base/Makefile
+++ b/modules/repository-base/base/Makefile
@@ -39,7 +39,7 @@
 # For details on some of these "prelude" settings, see:
 # https://clarkgrubb.com/makefile-style-guide
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
-SHELL := /usr/bin/env bash
+SHELL := /usr/bin/env PS1="" bash
 .SHELLFLAGS := -uo pipefail -c
 .DEFAULT_GOAL := help
 .DELETE_ON_ERROR:


### PR DESCRIPTION
As described here: https://groups.google.com/g/linux.debian.user/c/o83Ay6fTavc/m/8_fsjCdHAAAJ, some bashrc scripts do a PS1 variable check, but fail to account for the variable not existing.

By setting it to an empty value, we prevent users from seeing this confusing warning.