### PR TITLE
Rename Dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
   schedule:
     interval: weekly
   groups:
-    all:
+    all-go-deps:
       patterns: ["*"]
 - package-ecosystem: github-actions
   directories:
@@ -15,5 +15,5 @@ updates:
   schedule:
     interval: weekly
   groups:
-    all:
+    all-gh-actions:
       patterns: ["*"]

--- a/modules/repository-base/base-dependabot/.github/dependabot.yaml
+++ b/modules/repository-base/base-dependabot/.github/dependabot.yaml
@@ -9,12 +9,12 @@ updates:
   schedule:
     interval: daily
   groups:
-    all:
+    all-go-deps:
       patterns: ["*"]
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: daily
   groups:
-    all:
+    all-gh-actions:
       patterns: ["*"]


### PR DESCRIPTION
As Dependabot splits Go deps and GHA upgrades into separate PRs, I think it should be possible to understand from the PR title which type of deps are upgraded. Example PR, which triggered my proposal of this: https://github.com/cert-manager/webhook-cert-lib/pull/28