### PR TITLE
BUGFIX: make base dir variable names unique, fixing name collision bug

### DIFF
--- a/modules/boilerplate/01_mod.mk
+++ b/modules/boilerplate/01_mod.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
+license_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
 
 .PHONY: verify-boilerplate
 ## Verify that all files have the correct boilerplate.
@@ -26,6 +26,6 @@ shared_verify_targets += verify-boilerplate
 ## Generate LICENSE file in the repository
 ## @category [shared] Generate/ Verify
 generate-license:
-	cp -r $(base_dir)/. ./
+	cp -r $(license_base_dir)/. ./
 
 shared_generate_targets += generate-base

--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -61,16 +61,16 @@ generate-go-mod-tidy: | $(NEEDS_GO)
 
 shared_generate_targets += generate-go-mod-tidy
 
-base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
-
 ifndef dont_generate_govulncheck
+
+govulncheck_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
 
 .PHONY: generate-govulncheck
 ## Generate base files in the repository
 ## @category [shared] Generate/ Verify
 generate-govulncheck:
-	cp -r $(base_dir)/. ./
-	cd $(base_dir) && \
+	cp -r $(govulncheck_base_dir)/. ./
+	cd $(govulncheck_base_dir) && \
 		find . -type f | while read file; do \
 			sed "s|{{REPLACE:GH-REPOSITORY}}|$(repo_name:github.com/%=%)|g" "$$file" > "$(CURDIR)/$$file"; \
 		done

--- a/modules/repository-base/01_mod.mk
+++ b/modules/repository-base/01_mod.mk
@@ -16,16 +16,16 @@ ifndef repo_name
 $(error repo_name is not set)
 endif
 
-base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
-base_dependabot_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base-dependabot/
+repository_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
+repository_base_dependabot_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base-dependabot/
 
 ifdef repository_base_no_dependabot
 .PHONY: generate-base
 ## Generate base files in the repository
 ## @category [shared] Generate/ Verify
 generate-base:
-	cp -r $(base_dir)/. ./
-	cd $(base_dir) && \
+	cp -r $(repository_base_dir)/. ./
+	cd $(repository_base_dir) && \
 		find . -type f | while read file; do \
 			sed "s|{{REPLACE:GH-REPOSITORY}}|$(repo_name:github.com/%=%)|g" "$$file" > "$(CURDIR)/$$file"; \
 		done
@@ -34,12 +34,12 @@ else
 ## Generate base files in the repository
 ## @category [shared] Generate/ Verify
 generate-base:
-	cp -r $(base_dir)/. ./
-	cd $(base_dir) && \
+	cp -r $(repository_base_dir)/. ./
+	cd $(repository_base_dir) && \
 		find . -type f | while read file; do \
 			sed "s|{{REPLACE:GH-REPOSITORY}}|$(repo_name:github.com/%=%)|g" "$$file" > "$(CURDIR)/$$file"; \
 		done
-	cp -r $(base_dependabot_dir)/. ./
+	cp -r $(repository_base_dependabot_dir)/. ./
 endif
 
 shared_generate_targets += generate-base


### PR DESCRIPTION
The different `base_dir` variables were conflicting, causing the wrong base dir to be used by some targets.