### PR TITLE
Dependabot exclude paths for files managed by makefile-modules

### DIFF
--- a/modules/repository-base/base-dependabot/.github/dependabot.yaml
+++ b/modules/repository-base/base-dependabot/.github/dependabot.yaml
@@ -15,6 +15,9 @@ updates:
   directory: /
   schedule:
     interval: daily
+  exclude-paths: # Exclude files that are mastered from makefile-modules and shouldn't be upgraded in projects using makefile-modules.
+    - .github/workflows/govulncheck.yaml
+    - .github/workflows/make-self-upgrade.yaml
   groups:
     all-gh-actions:
       patterns: ["*"]


### PR DESCRIPTION
I just noticed that Dependabot released a new feature I've been looking for: https://github.com/dependabot/dependabot-core/issues/4364#issuecomment-3202381778.

This change should prevent Dependabot from suggesting upgrades in workflow files mastered from makefile-modules. 🥳