### PR TITLE
Set Renovate ignorePaths

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -87,4 +87,7 @@
       enabled: false,
     },
   ],
+  ignorePaths: [
+    '**/vendor/**',
+  ],
 }


### PR DESCRIPTION
As you can see from https://github.com/cert-manager/webhook-cert-lib/actions/runs/17191028619/job/48766673069, the default ignore paths in Renovate (with our selected presets) is:

````json
"ignorePaths": [
         "**/node_modules/**",
         "**/bower_components/**",
         "**/vendor/**",
         "**/examples/**",
         "**/__tests__/**",
         "**/test/**",
         "**/tests/**",
         "**/__fixtures__/**"
       ]
````

This ignores some paths that we want to let Renovate work on. Example: https://github.com/cert-manager/webhook-cert-lib/tree/main/test