### PR TITLE
Add labels to Dependabot PRs

### DIFF
--- a/modules/repository-base/base-dependabot/.github/dependabot.yaml
+++ b/modules/repository-base/base-dependabot/.github/dependabot.yaml
@@ -15,3 +15,8 @@ updates:
   groups:
     all-gh-actions:
       patterns: ["*"]
+  labels:
+    - dependencies
+    - kind/cleanup
+    - release-note-none
+    - ok-to-test


### PR DESCRIPTION
This should allow CI to run on Dependabot PRs automatically, so just a simple /lgtm and /approve is required to merge it. Example from cert-manager with the user action I would like to avoid: https://github.com/cert-manager/cert-manager/pull/8006