### PR TITLE
Make generate-go-mod-tidy target ensure Go toolchain is removed

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -55,6 +55,7 @@ generate-go-mod-tidy: | $(NEEDS_GO)
 				echo "Running 'go mod tidy' in directory '$${target}'"; \
 				pushd "$${target}" >/dev/null; \
 				$(GO) mod tidy || exit; \
+				$(GO) get toolchain@none || exit; \
 				popd >/dev/null; \
 				echo ""; \
 			done


### PR DESCRIPTION
This is done to avoid anyone from adding the unwanted Go toolchain directive to our go.mod files. Motivated by https://github.com/cert-manager/cmctl/pull/276#issuecomment-3219381036.