### PR TITLE
Onboard Renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,14 +1,6 @@
-# Update Go dependencies and GitHub Actions dependencies weekly.
+# Update GitHub Actions dependencies weekly.
 version: 2
 updates:
-- package-ecosystem: gomod
-  directories:
-    - "**/*"
-  schedule:
-    interval: weekly
-  groups:
-    all-go-deps:
-      patterns: ["*"]
 - package-ecosystem: github-actions
   directories:
     - "**/.github/workflows"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,30 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  enabled: true,
+  enabledManagers: [
+    'gomod',
+  ],
+  separateMajorMinor: false,
+  extends: [
+    'config:best-practices',
+    ':gitSignOff',
+    ':disableVulnerabilityAlerts',
+    ':prConcurrentLimit10', // Set a limit to avoid too many PRs, at least on the first run
+    ':prHourlyLimitNone',
+  ],
+  timezone: 'Europe/London',
+  packageRules: [
+    {
+      groupName: 'Misc Go deps',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        '*',
+      ],
+    },
+  ],
+  ignorePaths: [
+    '**/vendor/**',
+  ],
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,53 @@
+name: Renovate
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 8 * * 6' # weekly; 08:00 at Saturday
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    if: github.repository == 'cert-manager/makefile-modules'
+
+    permissions:
+      contents: write
+      issues: write
+      statuses: write
+      pull-requests: write
+
+    steps:
+      - name: Fail if branch is not head of branch.
+        if: ${{ !startsWith(github.ref, 'refs/heads/') && env.SOURCE_BRANCH != '' && env.SELF_UPGRADE_BRANCH != '' }}
+        run: |
+          echo "This workflow should not be run on a non-branch-head."
+          exit 1
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
+
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ steps.go-version.outputs.result }}
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@b11417b9eaac3145fe9a8544cee66503724e32b6 # v43.0.8
+        with:
+          configurationFile: .github/renovate.json5
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_PLATFORM: "github"
+          LOG_LEVEL: "debug"
+          RENOVATE_ALLOWED_COMMANDS: '["make generate"]'


### PR DESCRIPTION
Replacing Dependabot for Go updates in this project. I've used a simplified version of the Renovate setup provided to downstream projects. Main motivation is to use the regex manager in Renovate to suggest upgrades to tools in https://github.com/cert-manager/makefile-modules/blob/main/modules/tools/00_mod.mk.