### PR TITLE
Prepend generate-go-mod-tidy target instead of appending

### DIFF
--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -60,7 +60,7 @@ generate-go-mod-tidy: | $(NEEDS_GO)
 				echo ""; \
 			done
 
-shared_generate_targets += generate-go-mod-tidy
+shared_generate_targets := generate-go-mod-tidy $(shared_generate_targets)
 
 ifndef dont_generate_govulncheck
 


### PR DESCRIPTION
https://github.com/cert-manager/issuer-lib/pull/295 is failing because controller-gen is executed before the Go modules are tidied. To fix this issue, @ThatsMrTalbot suggested to prepend the `generate-go-mod-tidy` target instead of appending. I have tested that the change in this PR fixes the specific issue, and I don't think it should break anything else.