### PR TITLE
ci(renovate): unset separateMajorMinor and use default behavior

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,6 @@
   enabledManagers: [
     'gomod',
   ],
-  separateMajorMinor: false,
   extends: [
     'config:best-practices',
     ':gitSignOff',

--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -7,7 +7,6 @@
   enabledManagers: [
     'gomod',
   ],
-  separateMajorMinor: false,
   extends: [
     'config:best-practices',
     ':gitSignOff',


### PR DESCRIPTION
This was briefly discussed in today's stand-up, where I was happy to see @inteon again! The change suggested here, will return to the default Renovate behavior of separating patch/minor from major upgrades (separate PRs). This is also the recommended Renovate setting: https://docs.renovatebot.com/configuration-options/#separatemajorminor