### PR TITLE
ci(renovate): configure K8s patches to auto-merge

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -38,16 +38,6 @@
       ],
     },
     {
-      groupName: 'Kubernetes Go deps',
-      matchManagers: [
-        'gomod',
-      ],
-      matchPackageNames: [
-        'sigs.k8s.io**/**',
-        'k8s.io**/**',
-      ],
-    },
-    {
       groupName: 'Cloud Go deps',
       matchManagers: [
         'gomod',
@@ -61,6 +51,31 @@
         'github.com/digitalocean**/**',
         'google.golang.org/api',
       ],
+    },
+    {
+      groupName: 'Kubernetes Go deps',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'sigs.k8s.io**/**',
+        'k8s.io**/**',
+      ],
+    },
+    {
+      groupName: 'Kubernetes Go patches',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'k8s.io**/**',
+      ],
+      matchUpdateTypes: [
+        'patch',
+      ],
+      addLabels: [
+        'skip-review', // Adding label to allow PRs to automerge
+      ]
     },
     {
       groupName: 'golang.org/x deps',


### PR DESCRIPTION
I personally consider K8s (core) dependencies as reliable, and suggest enabling auto-merge for K8s patches. Renovate should match packageRules where the last one wins. I also moved the "extended" K8s group (including sigs modules) next to the new block.