### PR TITLE
ci(renovate): allow any postUpgradeTasks command

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -50,4 +50,4 @@ jobs:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_PLATFORM: "github"
           LOG_LEVEL: "debug"
-          RENOVATE_ALLOWED_COMMANDS: '["make generate"]'
+          RENOVATE_ALLOWED_COMMANDS: '[".*"]'

--- a/modules/repository-base/base-dependabot/.github/workflows/renovate.yaml
+++ b/modules/repository-base/base-dependabot/.github/workflows/renovate.yaml
@@ -53,4 +53,4 @@ jobs:
           RENOVATE_ONBOARDING: "false"
           RENOVATE_PLATFORM: "github"
           LOG_LEVEL: "debug"
-          RENOVATE_ALLOWED_COMMANDS: '["make generate"]'
+          RENOVATE_ALLOWED_COMMANDS: '[".*"]'


### PR DESCRIPTION
We were discussing running multiple postUpgradeTasks commands to fix a Renovate issue yesterday. As updating workflows from makefile-modules is a manual operation at present, I suggest allowing any command here. We control the Renovate config, so no need to be scared of the warnings here: https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands