### PR TITLE
ci(renovate): add 'make learn-tools-shas' to post upgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,12 @@
       ],
     },
   ],
+  postUpgradeTasks: {
+    commands: [
+      'make learn-tools-shas',
+    ],
+    executionMode: 'branch',
+  },
   packageRules: [
     {
       groupName: 'Tools',


### PR DESCRIPTION
To address https://github.com/cert-manager/makefile-modules/pull/347#issuecomment-3227179805. The command is very slow on my workstation, but let's hope it's a faster command in the "wild".