### PR TITLE
ci(renovate): add 'make vendor-go' to post upgrade tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,7 @@
   ],
   postUpgradeTasks: {
     commands: [
-      'make learn-tools-shas',
+      'make vendor-go learn-tools-shas',
     ],
     executionMode: 'branch',
   },


### PR DESCRIPTION
To hopefully address https://github.com/cert-manager/makefile-modules/pull/347#issuecomment-3227272655 (example).