### PR TITLE
ci(renovate): add additional regex to match more tools versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,8 @@
         'modules/tools/**',
       ],
       matchStrings: [
-        '(?:^|\\r\\n|\\r|\\n)#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:^|\\r\\n|\\r|\\n)tools \\+= \\S+=(?<currentValue>\\S+)'
+        '(?:^|\\r\\n|\\r|\\n)#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:^|\\r\\n|\\r|\\n)\\S+ \\+= \\S+=(?<currentValue>\\S+)',
+        '(?:^|\\r\\n|\\r|\\n)#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:^|\\r\\n|\\r|\\n)\\S+ := (?<currentValue>\\S+)'
       ],
     },
   ],


### PR DESCRIPTION
To address https://github.com/cert-manager/makefile-modules/pull/353#discussion_r2304066505. I have tested the two regexes on https://regex101.com/.

The new regex should match patterns like this one:

````
# renovate: datasource=github-tags packageName=kubernetes/code-generator
K8S_CODEGEN_VERSION := v0.33.3
````