### PR TITLE
Disable Dependabot gh-action downstream upgrades

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ version: 2
 updates:
 - package-ecosystem: github-actions
   directories:
-    - "**/.github/workflows"
+    - "/"
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
The manual self-upgrades are extremely painful to do, and Renovate is updated a lot more frequently than any other workflow we use (JavaScript methodology). And each time any downstream workflow files are touched, a manual self-upgrade is required. And until it's done, all automated self-upgrades are blocked (trunk-based).

So until we can find a good solution to automate the downstream workflow updates, I suggest preventing Dependabot from suggesting upgrades to those files.

I have made a POC project proving that we can do this with a little help from Octo STS, and plan to bring this suggestion up for our next bi-weekly meeting. https://github.com/erikgb/octo-sts-testing