### PR TITLE
Allow overriding K8S_CODEGEN_VERSION in downstream projects

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -170,9 +170,10 @@ tools += yamlfmt=v0.17.2
 # renovate: datasource=github-releases packageName=yannh/kubeconform
 tools += kubeconform=v0.7.0
 
+# FIXME(erikgb): cert-manager needs the ability to override the version set here
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 # renovate: datasource=go packageName=k8s.io/code-generator
-K8S_CODEGEN_VERSION := v0.34.0
+K8S_CODEGEN_VERSION ?= v0.34.0
 tools += client-gen=$(K8S_CODEGEN_VERSION)
 tools += deepcopy-gen=$(K8S_CODEGEN_VERSION)
 tools += informer-gen=$(K8S_CODEGEN_VERSION)


### PR DESCRIPTION
This PR allows downstream projects to override the K8s codegen version. The minor (temporary?) change is required to do a manual self-upgrade in cert-manager. The K8s upgrade in cert-manager has various issues that will need some time to fix.

I have verified that this change allows me to fix the self-upgrade in cert-manager.

WIP PR: https://github.com/cert-manager/cert-manager/pull/8019