### PR TITLE
ci(renovate): add group for Go testing dependencies

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -38,6 +38,17 @@
       ],
     },
     {
+      groupName: 'Testing Go deps',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/onsi/ginkgo**/**',
+        'github.com/onsi/gomega**/**',
+        'github.com/stretchr/testify**/**',
+      ],
+    },
+    {
       groupName: 'Kubernetes Go deps',
       matchManagers: [
         'gomod',


### PR DESCRIPTION
I propose adding a dedicated group for Go testing dependencies. Some of them, like Ginkgo and Gomega, are released "all the time". So there is no harm in leaving the upgrade PRs open for a while. Or configure them to auto-merge later on, if we considider it safe enough.

Right now, these upgrades might hide (more important) upgrades inside the "Misc Go deps" group. Example: https://github.com/cert-manager/google-cas-issuer/pull/307