### PR TITLE
Add ok-to-test label to downstream Renovate PRs

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -19,6 +19,7 @@
   labels: [
     'dependencies',
     'kind/cleanup',
+    'ok-to-test',
     'release-note-none',
   ],
   postUpgradeTasks: {


### PR DESCRIPTION
Using Octo STS, the `ok-to-test` label is required to trigger CI. I am planning to cherry-pick this into the octo-sts-poc branch.