### PR TITLE
Use token obtained from Octo STS for Git operations

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -77,6 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/{{REPLACE:GH-REPOSITORY}}.git"
           git config --global user.name "cert-manager-bot"
           git config --global user.email "cert-manager-bot@users.noreply.github.com"
           git add -A && git commit -m "BOT: run 'make upgrade-klone' and 'make generate'" --signoff


### PR DESCRIPTION
Hopefully, this will fix https://github.com/cert-manager/helm-tool/actions/runs/17344118761/job/49241856449.

Credits: ChatGPT (so please suggest something better)