### PR TITLE
Add vendor-go target to Renovate postUpgradeTasks

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -25,7 +25,7 @@
   ],
   postUpgradeTasks: {
     commands: [
-      'make generate',
+      'make vendor-go generate',
     ],
     executionMode: 'branch',
   },


### PR DESCRIPTION
I have a hunch that this might fix the artifact update errors in https://github.com/cert-manager/helm-tool/pull/142.