### PR TITLE
Simplify use of Octo STS token in self-upgrade workflow

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -32,11 +32,20 @@ jobs:
           echo "This workflow should not be run on a non-branch-head."
           exit 1
 
+      - name: Octo STS Token Exchange
+        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
+        id: octo-sts
+        with:
+          scope: '{{REPLACE:GH-REPOSITORY}}'
+          identity: make-self-upgrade
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
         # the tags so `git describe` returns a valid version.
         # see https://github.com/actions/checkout/issues/701 for extra info about this option
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - id: go-version
         run: |
@@ -66,18 +75,7 @@ jobs:
           echo "result=$is_up_to_date" >> "$GITHUB_OUTPUT"
 
       - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
-        name: Octo STS Token Exchange
-        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
-        id: octo-sts
-        with:
-          scope: '{{REPLACE:GH-REPOSITORY}}'
-          identity: make-self-upgrade
-
-      - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/{{REPLACE:GH-REPOSITORY}}.git"
           git config --global user.name "cert-manager-bot"
           git config --global user.email "cert-manager-bot@users.noreply.github.com"
           git add -A && git commit -m "BOT: run 'make upgrade-klone' and 'make generate'" --signoff
@@ -85,8 +83,6 @@ jobs:
 
       - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        env:
-          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         with:
           script: |
             const { repo, owner } = context.repo;


### PR DESCRIPTION
This will perform the token exchange on each run. Seems a lot simpler.