### PR TITLE
Grant make-self-upgrade write access to workflows

### DIFF
--- a/modules/repository-base/base/.github/chainguard/make-self-upgrade.sts.yaml
+++ b/modules/repository-base/base/.github/chainguard/make-self-upgrade.sts.yaml
@@ -4,3 +4,4 @@ subject_pattern: repo:{{REPLACE:GH-REPOSITORY}}:ref:refs/heads/(main|master)
 permissions:
   contents: write
   pull_requests: write
+  workflows: write


### PR DESCRIPTION
This was missed in the initial setup of Octo STS policies. One of the main goals to solve here was to give make-self-upgrade access to update project workflows.