### PR TITLE
Remove Renovate push trigger

### DIFF
--- a/modules/repository-base/base-dependabot/.github/workflows/renovate.yaml
+++ b/modules/repository-base/base-dependabot/.github/workflows/renovate.yaml
@@ -3,10 +3,6 @@
 
 name: Renovate
 on:
-  push:
-    branches:
-      - main
-      - master
   workflow_dispatch: {}
   schedule:
     - cron: '0/30 * * * *'


### PR DESCRIPTION
While testing https://www.cubic.dev/ on my own fork of this project, it provided some good feedback around adding the push trigger to the Renovate workflow: https://github.com/erikgb/makefile-modules/pull/1#discussion_r2312326906

I think the schedule + workflow trigger is enough.