### PR TITLE
Align make-self-upgrade and renovate workflows

### DIFF
--- a/modules/repository-base/base-dependabot/.github/workflows/renovate.yaml
+++ b/modules/repository-base/base-dependabot/.github/workflows/renovate.yaml
@@ -21,7 +21,6 @@ jobs:
     if: github.repository == '{{REPLACE:GH-REPOSITORY}}'
 
     permissions:
-      contents: read
       id-token: write
 
     steps:
@@ -31,11 +30,20 @@ jobs:
           echo "This workflow should not be run on a non-branch-head."
           exit 1
 
+      - name: Octo STS Token Exchange
+        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
+        id: octo-sts
+        with:
+          scope: '{{REPLACE:GH-REPOSITORY}}'
+          identity: renovate
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
         # the tags so `git describe` returns a valid version.
         # see https://github.com/actions/checkout/issues/701 for extra info about this option
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - id: go-version
         run: |
@@ -44,13 +52,6 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
-
-      - name: Octo STS Token Exchange
-        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
-        id: octo-sts
-        with:
-          scope: '{{REPLACE:GH-REPOSITORY}}'
-          identity: renovate
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@a447f09147d00e00ae2a82ad5ef51ca89352da80 # v43.0.9

--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -18,7 +18,6 @@ jobs:
     if: github.repository == '{{REPLACE:GH-REPOSITORY}}'
 
     permissions:
-      contents: read
       id-token: write
     
     env:


### PR DESCRIPTION
With the last-minute changes yesterday, the `contents: read` permission is no longer required in the make-self-upgrade workflow. More importantly, this PR aligns the workflows, since they are very similar.