### PR TITLE
Migrate renovate workflow to use Octo STS

### DIFF
--- a/.github/chainguard/renovate.sts.yaml
+++ b/.github/chainguard/renovate.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:cert-manager/makefile-modules:ref:refs/heads/main
+
+permissions:
+  administration: read
+  contents: write
+  issues: write
+  pull_requests: write
+  security_events: read
+  statuses: write
+  workflows: write

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -14,10 +14,7 @@ jobs:
     if: github.repository == 'cert-manager/makefile-modules'
 
     permissions:
-      contents: write
-      issues: write
-      statuses: write
-      pull-requests: write
+      id-token: write
 
     steps:
       - name: Fail if branch is not head of branch.
@@ -26,11 +23,20 @@ jobs:
           echo "This workflow should not be run on a non-branch-head."
           exit 1
 
+      - name: Octo STS Token Exchange
+        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
+        id: octo-sts
+        with:
+          scope: '{{REPLACE:GH-REPOSITORY}}'
+          identity: renovate
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
         # the tags so `git describe` returns a valid version.
         # see https://github.com/actions/checkout/issues/701 for extra info about this option
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - id: go-version
         run: |
@@ -44,7 +50,7 @@ jobs:
         uses: renovatebot/github-action@a447f09147d00e00ae2a82ad5ef51ca89352da80 # v43.0.9
         with:
           configurationFile: .github/renovate.json5
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ONBOARDING: "false"


### PR DESCRIPTION
As it's now unable to upgrade workflows, ref. https://github.com/cert-manager/makefile-modules/actions/runs/17356366216/job/49269912432#step:6:4012.