### PR TITLE
Fix copy-pasted Octo STS scope

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
         id: octo-sts
         with:
-          scope: '{{REPLACE:GH-REPOSITORY}}'
+          scope: cert-manager/makefile-modules
           identity: renovate
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
There was a bug in https://github.com/cert-manager/makefile-modules/pull/375.