### PR TITLE
Use Octo STS token to create self-upgrade PR

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -83,6 +83,7 @@ jobs:
       - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const pulls = await github.rest.pulls.list({


### PR DESCRIPTION
It attempts to use the default token, which doesn't have permission to do this now: https://github.com/cert-manager/webhook-cert-lib/actions/runs/17356874882/job/49271168311