### PR TITLE
Add ok-to-test label to self-upgrade PRs

### DIFF
--- a/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
+++ b/modules/repository-base/base/.github/workflows/make-self-upgrade.yaml
@@ -100,6 +100,6 @@ jobs:
                 owner,
                 repo,
                 issue_number: result.data.number,
-                labels: ['skip-review']
+                labels: ['ok-to-test', 'skip-review']
               });
             }


### PR DESCRIPTION
Now that we use a token from Octo STS, this is required to trigger workflows. Example: https://github.com/cert-manager/webhook-cert-lib/pull/63

I see no harm in merging this to the main branch, even if we decide to not move forward with Octo STS.

/cherry-pick octo-sts-poc
/cc @ThatsMrTalbot 