### PR TITLE
Fix misbehaving Renovate Git author settings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,8 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
-  gitAuthor: 'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
+  gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
+  recreateWhen: 'always', // TODO: Remove; temporary fix to force Renovate to ignore "foreign" commits
   enabledManagers: [
     'custom.regex',
     'github-actions',

--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -4,7 +4,8 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
-  gitAuthor: 'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
+  gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
+  recreateWhen: 'always', // TODO: Remove; temporary fix to force Renovate to ignore "foreign" commits
   enabledManagers: [
     'gomod',
   ],


### PR DESCRIPTION
It seems like we are hit by the "Danger" box documented here: https://docs.renovatebot.com/configuration-options/#gitauthor

<img width="794" height="165" alt="image" src="https://github.com/user-attachments/assets/bdf0c9e8-5456-4394-9d5a-b4a947f565d7" />

Also, setting the `recreateWhen` option as a hopefully easy fix across our projects. It seems like Renovate is confused by it's own commits. 🤔 Example: https://github.com/cert-manager/trust-manager/issues/701

/cc @inteon 