### PR TITLE
Fix gotestsum Renovate config

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -109,7 +109,7 @@ tools += goimports=v0.35.0
 # https://pkg.go.dev/github.com/google/go-licenses/v2?tab=versions
 tools += go-licenses=e4be799587800ffd119a1b419f13daf4989da546
 # https://pkg.go.dev/gotest.tools/gotestsum?tab=versions
-# renovate: datasource=go packageName=gotest.tool/gotestsum
+# renovate: datasource=github-releases packageName=gotestyourself/gotestsum
 tools += gotestsum=v1.12.3
 # https://pkg.go.dev/sigs.k8s.io/kustomize/kustomize/v5?tab=versions
 # renovate: datasource=go packageName=sigs.k8s.io/kustomize/kustomize/v5


### PR DESCRIPTION
As can be seen in the Renovate Dependency Dashboard, https://github.com/cert-manager/makefile-modules/issues/379, Renovate is unable to resolve the Go dependency. As a simple fix, I suggest reconfiguring it to track their GH releases instead, which should be equivalent.

<img width="812" height="146" alt="image" src="https://github.com/user-attachments/assets/79da63d1-224a-4f59-bec8-37f89ac79fe4" />

/cc @inteon 