### PR TITLE
General Renovate config improvements

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,17 +56,11 @@
       matchManagers: [
         'custom.regex',
       ],
-      matchPackageNames: [
-        '*',
-      ]
     },
     {
       groupName: 'Misc GitHub actions',
       matchManagers: [
         'github-actions',
-      ],
-      matchPackageNames: [
-        '*',
       ],
       enabled: true,
       matchBaseBranches: [
@@ -77,9 +71,6 @@
       groupName: 'Misc Go deps',
       matchManagers: [
         'gomod',
-      ],
-      matchPackageNames: [
-        '*',
       ],
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,12 +28,6 @@
       ],
     },
   ],
-  postUpgradeTasks: {
-    commands: [
-      'make vendor-go learn-tools-shas',
-    ],
-    executionMode: 'branch',
-  },
   baseBranchPatterns: [
     'main',
     'octo-sts-poc',
@@ -56,6 +50,12 @@
       matchManagers: [
         'custom.regex',
       ],
+      postUpgradeTasks: {
+        commands: [
+          'make vendor-go learn-tools-shas',
+        ],
+        executionMode: 'branch',
+      }
     },
     {
       groupName: 'Misc GitHub actions',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,17 @@
         'gomod',
       ],
     },
+    {
+      matchManagers: [
+        'custom.regex',
+        'gomod',
+      ],
+      matchUpdateTypes: [
+        'major',
+        'digest',
+      ],
+      dependencyDashboardApproval: true
+    }
   ],
   ignorePaths: [
     '**/vendor/**',

--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -102,9 +102,22 @@
       ],
     },
     {
-      description: 'Disable Go pseudo-version updates',
       matchManagers: [
         'gomod',
+      ],
+      matchUpdateTypes: [
+        'major',
+        'digest',
+      ],
+      dependencyDashboardApproval: true
+    },
+    {
+      description: 'Disable (internal) cert-manager pseudo-version updates',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        'github.com/cert-manager/**',
       ],
       matchCurrentValue: 'v0.0.0*',
       enabled: false,

--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -37,9 +37,6 @@
       matchManagers: [
         'gomod',
       ],
-      matchPackageNames: [
-        '*',
-      ],
     },
     {
       groupName: 'Testing Go deps',
@@ -108,9 +105,6 @@
       description: 'Disable Go pseudo-version updates',
       matchManagers: [
         'gomod',
-      ],
-      matchPackageNames: [
-        '*',
       ],
       matchCurrentValue: 'v0.0.0*',
       enabled: false,


### PR DESCRIPTION
This Pr is trying to improve the Renovate configuration even more. It consists of a separate commit for each improvement:

1. Remove redundant match all packages. The matchers inside packageRules only filter matching upgrades. As long as we have at least one match filter, Renovate is happy.
2. Move postUpgradeTasks into packageRules to avoid running heavy workflow jobs when not required to, e.g., to upgrade GHA.
3. DependencyDashboardApproval for major/digest upgrades in general. I hope this will work a little better than https://github.com/cert-manager/cert-manager/pull/8014 (example). The goal here is to be able to request one major upgrade PR at a time, which will make it easier to work with the upgrade, as major upgrades typically require manual work.