### PR TITLE
ci(renovate): fix dependencyDashboardApproval for major/digest

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -37,6 +37,10 @@
       matchManagers: [
         'gomod',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
     },
     {
       groupName: 'Testing Go deps',
@@ -48,6 +52,10 @@
         'github.com/onsi/gomega',
         'github.com/stretchr/testify',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ]
     },
     {
       groupName: 'Cloud Go deps',
@@ -63,6 +71,10 @@
         'github.com/digitalocean/**',
         'google.golang.org/api',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ]
     },
     {
       groupName: 'Kubernetes Go deps',


### PR DESCRIPTION
My attempt to configure depedency dashboard approval didn't work, ref.
- https://github.com/cert-manager/cert-manager/pull/8028
- https://github.com/cert-manager/cert-manager/pull/8014

And, I hope this could make it better, even if it's a bit more duplication than I prefer.

/cc @hjoshi123 @ThatsMrTalbot 