### PR TITLE
ci(renovate): fix digest K8s dependencies

### DIFF
--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -85,6 +85,10 @@
         'sigs.k8s.io/**',
         'k8s.io/**',
       ],
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ]
     },
     {
       groupName: 'Kubernetes Go patches',


### PR DESCRIPTION
This PR fixes an oversight in https://github.com/cert-manager/makefile-modules/pull/393. This seems to work for non-K8s dependencies, ref. https://github.com/cert-manager/cert-manager/issues/7924, but https://github.com/cert-manager/cert-manager/pull/8028 is still there. 😢 

/cc @ThatsMrTalbot 