### PR TITLE
ci(renovate): configure gitIgnoredAuthors to avoid PRs detected as edited

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,10 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
   gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
+  gitIgnoredAuthors: [
+    'Renovate Bot <renovate-bot@users.noreply.github.com>',
+    'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
+  ],
   recreateWhen: 'always', // TODO: Remove; temporary fix to force Renovate to ignore "foreign" commits
   enabledManagers: [
     'custom.regex',

--- a/modules/repository-base/base-dependabot/.github/renovate.json5
+++ b/modules/repository-base/base-dependabot/.github/renovate.json5
@@ -5,6 +5,10 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
   gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
+  gitIgnoredAuthors: [
+    'Renovate Bot <renovate-bot@users.noreply.github.com>',
+    'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
+  ],
   recreateWhen: 'always', // TODO: Remove; temporary fix to force Renovate to ignore "foreign" commits
   enabledManagers: [
     'github-actions',


### PR DESCRIPTION
This could hopefully solve the issue shown here: (example): https://github.com/cert-manager/csi-driver/issues/451

<img width="915" height="182" alt="image" src="https://github.com/user-attachments/assets/9970b074-1822-4a8a-8ec5-075d536c0e49" />

Docs: https://docs.renovatebot.com/configuration-options/#gitignoredauthors