### PR TITLE
Disable Renovate for github.com/inteon/go-licenses dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,12 @@
         'digest',
       ],
       dependencyDashboardApproval: true
+    },
+    {
+      matchPackageNames: [
+        'github.com/inteon/go-licenses/**', // FIXME(inteon): See if we can get back to upstream go-licenses
+      ],
+      enabled: false,
     }
   ],
   ignorePaths: [


### PR DESCRIPTION
This should make Renovate take the dependency out of https://github.com/cert-manager/makefile-modules/pull/401 and allow it to be merged.