### PR TITLE
Configure Renovate to rebase stale PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,6 @@
     'Renovate Bot <renovate-bot@users.noreply.github.com>',
     'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
   ],
-  recreateWhen: 'always', // TODO: Remove; temporary fix to force Renovate to ignore "foreign" commits
   enabledManagers: [
     'custom.regex',
     'github-actions',
@@ -16,6 +15,7 @@
     'config:best-practices',
     ':gitSignOff',
     ':disableVulnerabilityAlerts',
+    ':rebaseStalePrs',
     ':prConcurrentLimit10', // Set a limit to avoid too many PRs, at least on the first run
     ':prHourlyLimitNone',
   ],

--- a/modules/repository-base/base/.github/renovate.json5
+++ b/modules/repository-base/base/.github/renovate.json5
@@ -9,7 +9,6 @@
     'Renovate Bot <renovate-bot@users.noreply.github.com>',
     'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
   ],
-  recreateWhen: 'always', // TODO: Remove; temporary fix to force Renovate to ignore "foreign" commits
   enabledManagers: [
     'github-actions',
     'gomod',
@@ -19,6 +18,7 @@
     ':gitSignOff',
     ':semanticCommits',
     ':disableVulnerabilityAlerts',
+    ':rebaseStalePrs',
     ':prConcurrentLimit10', // Set a limit to avoid too many PRs, at least on the first run
     ':prHourlyLimitNone',
   ],


### PR DESCRIPTION
The recreateWhen setting removed in this PR didn't help at all, so I want to try a new approach. While the constant rebasing could appear pretty "noisy", I would like to see if it can improve the current situation, described here: https://github.com/renovatebot/renovate/discussions/37868.