### PR TITLE
Dedicated (non) group for Golang upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,18 @@
       }
     },
     {
+      group: null,
+      matchDatasources: [
+        'golang-version',
+      ],
+      separateMinorPatch: true,
+      postUpgradeTasks: {
+        commands: [
+          'make learn-golang-shas',
+        ],
+      },
+    },
+    {
       groupName: 'Misc GitHub actions',
       matchManagers: [
         'github-actions',

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ learn-tools-shas: | $(NEEDS_CRANE)
 	@CRANE=$(CRANE) \
 		./scripts/learn_kind_images.sh
 
+# Learn the shas for the vendored Go version in the go module.
+# This must be run whenever the Go version is updated.
+.PHONY: learn-golang-shas
+learn-golang-shas:
+	./scripts/learn_tools_shas.sh _bin/tools/go
+
 .PHONY: learn-image-shas
 learn-image-shas: | $(NEEDS_CRANE)
 	@CRANE=$(CRANE) \
@@ -111,6 +117,7 @@ help: ## Show this help
 	@echo "make upgrade-base-images"
 	@echo "make upgrade-kind-images"
 	@echo
+	@echo "make learn-golang-shas"
 	@echo "make learn-tools-shas"
 	@echo "make learn-image-shas"
 	@echo


### PR DESCRIPTION
To hopefully fix https://github.com/cert-manager/makefile-modules/pull/412, but also a step towards configuring auto-merge for Golang upgrades.

/cc @ThatsMrTalbot 