### PR TITLE
Set Renovate gitIgnoredAuthors to fix "modified by someone else"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,8 +3,7 @@
   enabled: true,
   gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
   gitIgnoredAuthors: [
-    'Renovate Bot <renovate-bot@users.noreply.github.com>',
-    'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
+    '157150467+octo-sts[bot]@users.noreply.github.com',
   ],
   enabledManagers: [
     'custom.regex',

--- a/modules/repository-base/base/.github/renovate.json5
+++ b/modules/repository-base/base/.github/renovate.json5
@@ -6,8 +6,7 @@
   enabled: true,
   gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
   gitIgnoredAuthors: [
-    'Renovate Bot <renovate-bot@users.noreply.github.com>',
-    'cert-manager-bot <cert-manager-bot@users.noreply.github.com>',
+    '157150467+octo-sts[bot]@users.noreply.github.com',
   ],
   enabledManagers: [
     'github-actions',


### PR DESCRIPTION
I got an answer from Renovate folks: https://github.com/renovatebot/renovate/discussions/37868#discussioncomment-14327259. It seems like the "unrecognized author" is stable across our org. Now we know where/how to check if this happens again.

/cc @ThatsMrTalbot 