### PR TITLE
Make the local Renovate config extend shared preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,24 +1,13 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  enabled: true,
-  gitAuthor: 'Renovate Bot <renovate-bot@users.noreply.github.com>',
-  gitIgnoredAuthors: [
-    '157150467+octo-sts[bot]@users.noreply.github.com',
+  extends: [
+    'github>cert-manager/renovate-config:default.json5',
   ],
   enabledManagers: [
     'custom.regex',
     'github-actions',
     'gomod',
   ],
-  extends: [
-    'config:best-practices',
-    ':gitSignOff',
-    ':disableVulnerabilityAlerts',
-    ':rebaseStalePrs',
-    ':prConcurrentLimit10', // Set a limit to avoid too many PRs, at least on the first run
-    ':prHourlyLimitNone',
-  ],
-  timezone: 'Europe/London',
   customManagers: [
     {
       customType: 'regex',
@@ -57,27 +46,14 @@
       },
     },
     {
-      groupName: 'Misc GitHub actions',
-      matchManagers: [
-        'github-actions',
-      ],
-    },
-    {
-      groupName: 'Misc Go deps',
-      matchManagers: [
-        'gomod',
-      ],
-    },
-    {
       matchManagers: [
         'custom.regex',
-        'gomod',
       ],
       matchUpdateTypes: [
         'major',
         'digest',
       ],
-      dependencyDashboardApproval: true
+      dependencyDashboardApproval: true,
     },
     {
       matchPackageNames: [
@@ -85,8 +61,5 @@
       ],
       enabled: false,
     }
-  ],
-  ignorePaths: [
-    '**/vendor/**',
   ],
 }


### PR DESCRIPTION
My main motivation was not to duplicate the changes done in https://github.com/cert-manager/renovate-config/pull/10 after I saw https://github.com/cert-manager/makefile-modules/pull/421.

/cc @ThatsMrTalbot @hjoshi123 