### PR TITLE
Correct GHA version markers

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           make print-go-version >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: ${{ steps.go-version.outputs.result }}
 

--- a/modules/repository-base/base/.github/workflows/renovate.yaml
+++ b/modules/repository-base/base/.github/workflows/renovate.yaml
@@ -27,7 +27,7 @@ jobs:
           exit 1
 
       - name: Octo STS Token Exchange
-        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # main
+        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # v1.0.1
         id: octo-sts
         with:
           scope: '{{REPLACE:GH-REPOSITORY}}'


### PR DESCRIPTION
I prefer to see the human-readable exact version - even if we use digests.