### PR TITLE
Update the RenovateBot GitHub Action from v43.0.10 to v43.0.12 in the repo base workflow file

### DIFF
--- a/modules/repository-base/base/.github/workflows/renovate.yaml
+++ b/modules/repository-base/base/.github/workflows/renovate.yaml
@@ -50,7 +50,7 @@ jobs:
           go-version: ${{ steps.go-version.outputs.result }}
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@7876d7a812254599d262d62b6b2c2706018258a2 # v43.0.10
+        uses: renovatebot/github-action@f8af9272cd94a4637c29f60dea8731afd3134473 # v43.0.12
         with:
           configurationFile: .github/renovate.json5
           token: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
In https://github.com/jetstack/jetstack-secure/pull/724, Dependabot keeps trying to update this and failing because it's part of the makefile-modules base. So I thought I'd quickly update it here instead.
Is Renovate was supposed to update this itself?

See the [RenovateBot v43.0.12 release notes](https://github.com/renovatebot/github-action/releases/tag/v43.0.12).