### PR TITLE
Don't ignore sourced workflow files

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,4 +82,8 @@
       enabled: false,
     }
   ],
+  // Override the default ignorePaths in the shared preset, as files are sourced from here.
+  ignorePaths: [
+    '**/vendor/**',
+  ]
 }


### PR DESCRIPTION
The file patterns ignored by default in the shared Renovate preset have to be unignored here, ref. https://github.com/cert-manager/renovate-config/blob/6b95dd749c240f5d099df5dccb196705c2b3debc/default.json5#L142-L146

I think this PR should make Renovate suggest upgrades inside makefiles-modules modules as well. And avoid manual PRs as https://github.com/cert-manager/makefile-modules/pull/432.

/cc @wallrj @wallrj-cyberark 