### PR TITLE
Make Renovate ungroup major/digest upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,7 @@
       },
     },
     {
+      groupName: null,
       matchManagers: [
         'custom.regex',
       ],
@@ -73,7 +74,6 @@
         'major',
         'digest',
       ],
-      dependencyDashboardApproval: true,
     },
     {
       matchPackageNames: [


### PR DESCRIPTION
Looking at https://github.com/cert-manager/makefile-modules/pull/447, I want to merge the Proto upgrade, but probably wait for the Cosign major upgrade. This PR should make Renovate split that PR into two.