### PR TITLE
Add new modernize golangci-lint linter

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -45,6 +45,7 @@ linters:
     - makezero
     - mirror
     - misspell
+    - modernize
     - musttag
     - nakedret
     - nilerr


### PR DESCRIPTION
I would like to add the new [modernize](https://golangci-lint.run/docs/linters/configuration/#modernize) golangci-lint linter. It will probably require some (good) fixes across our projects, but it appears very useful to me. We onboarded it onto a couple of our private projects this week, and I really like the code cleanup it suggests.