### PR TITLE
Simplify GCI golangci-lint config with localmodule

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -70,10 +70,11 @@ formatters:
   enable: [ gci, gofmt ]
   settings:
     gci:
+      custom-order: true
       sections:
         - standard # Standard section: captures all standard packages.
         - default # Default section: contains all imports that could not be matched to another section type.
-        - prefix({{REPO-NAME}}) # Custom section: groups all imports with the specified Prefix.
+        - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
         - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
         - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
   exclusions:

--- a/modules/go/01_mod.mk
+++ b/modules/go/01_mod.mk
@@ -117,7 +117,6 @@ generate-golangci-lint-config: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/s
 	cp $(golangci_lint_config) $(bin_dir)/scratch/golangci-lint.yaml.tmp
 	$(YQ) -i 'del(.linters.enable)' $(bin_dir)/scratch/golangci-lint.yaml.tmp
 	$(YQ) eval-all -i '. as $$item ireduce ({}; . * $$item)' $(bin_dir)/scratch/golangci-lint.yaml.tmp $(golangci_lint_override)
-	$(YQ) -i '(.. | select(tag == "!!str")) |= sub("{{REPO-NAME}}", "$(repo_name)")' $(bin_dir)/scratch/golangci-lint.yaml.tmp
 	mv $(bin_dir)/scratch/golangci-lint.yaml.tmp $(golangci_lint_config)
 
 shared_generate_targets += generate-golangci-lint-config


### PR DESCRIPTION
This is a (slightly modified) cherry-pick of https://github.com/cert-manager/makefile-modules/pull/312, which was later reverted in https://github.com/cert-manager/makefile-modules/pull/328. The missing piece was setting the `custom-order` setting to `true`, ref. https://golangci-lint.run/docs/formatters/configuration/#gci.

I have tested this again with golangci-lint 2.6.0, and it works now. And it seems like the `golangci-lint run --fix` proposed in https://github.com/cert-manager/makefile-modules/pull/467 requires us to use `localmodule` instead of `prefix` to do the right thing.