### PR TITLE
Disable modernize omitzero analyzer for now

### DIFF
--- a/modules/go/.golangci.override.yaml
+++ b/modules/go/.golangci.override.yaml
@@ -7,6 +7,10 @@ linters:
     paths: [ third_party, builtin$, examples$ ]
     warn-unused: true
   settings:
+    modernize:
+      disable:
+        # TODO(erikgb): enable this check when we have discussed how to migrate from omitempty to omitzero
+        - omitzero
     staticcheck:
       checks: [ "all", "-ST1000", "-ST1001", "-ST1003", "-ST1005", "-ST1012", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-QF1001", "-QF1003", "-QF1008" ]
   enable:


### PR DESCRIPTION
This new analyzer generates a lot of new lint errors across our projects, and I think we need some time to discuss how to move forward with this.

See https://github.com/cert-manager/approver-policy/pull/739#issuecomment-3476839550 for context.