### PR TITLE
Configure renovation of cert-manager version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,8 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        'modules/tools/**',
+        'modules/cert-manager/**/*.mk',
+        'modules/tools/**/*.mk',
       ],
       matchStrings: [
         '(?:^|\\r\\n|\\r|\\n)#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+packageName=(?<packageName>\\S+)(?:^|\\r\\n|\\r|\\n)\\S+ \\+= \\S+=(?<currentValue>\\S+)',
@@ -22,7 +23,7 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        'modules/tools/**',
+        'modules/tools/**/*.mk',
       ],
       depNameTemplate: 'envtest',
       matchStrings: [
@@ -42,9 +43,23 @@
   },
   packageRules: [
     {
+      matchManagers: [
+        'custom.regex',
+      ],
+      postUpgradeTasks: {
+        commands: [
+          'make learn-image-shas',
+        ],
+        executionMode: 'branch',
+      }
+    },
+    {
       groupName: 'Tools',
       matchManagers: [
         'custom.regex',
+      ],
+      matchFileNames: [
+        'modules/tools/**/*.mk',
       ],
       postUpgradeTasks: {
         commands: [

--- a/modules/cert-manager/00_mod.mk
+++ b/modules/cert-manager/00_mod.mk
@@ -15,6 +15,7 @@
 images_amd64 ?=
 images_arm64 ?=
 
+# renovate: datasource=github-releases packageName=cert-manager/cert-manager
 cert_manager_version := v1.18.2
 
 images_amd64 += quay.io/jetstack/cert-manager-controller:$(cert_manager_version)@sha256:058a3ee5b133f964acefbd5926a08ace1fb7c0775b92d3bc11e4c7a33de71e25


### PR DESCRIPTION
I noticed that the cert-manager version in the cert-manager module was outdated. This should make Renovate suggest upgrades for it (ungrouped).