### PR TITLE
move VENDORED_GO_VERSION to top of file

### DIFF
--- a/modules/tools/00_mod.mk
+++ b/modules/tools/00_mod.mk
@@ -30,6 +30,10 @@ endif
 export DOWNLOAD_DIR ?= $(default_shared_dir)/downloaded
 export GOVENDOR_DIR ?= $(default_shared_dir)/go_vendor
 
+# https://go.dev/dl/
+# renovate: datasource=golang-version packageName=go
+VENDORED_GO_VERSION := 1.26.2
+
 $(bin_dir)/tools $(DOWNLOAD_DIR)/tools:
 	@mkdir -p $@
 
@@ -221,10 +225,6 @@ tools += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 # Additional tools can be defined to reuse the tooling in this file
 ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
-
-# https://go.dev/dl/
-# renovate: datasource=golang-version packageName=go
-VENDORED_GO_VERSION := 1.26.2
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version


### PR DESCRIPTION
I open the tools module in my editor several times a week across different projects to answer the question "what Go version is this project using?"

This is a tiny quality-of-life fix which makes that question easier to answer, saving me from having to scroll / search and just putting the value at the top of the file.

If it's any help at all, here's what claude says about this very simple change:

```text
No, there's no reason to expect problems from this change.

  The uncommitted change in modules/tools/00_mod.mk simply moves the VENDORED_GO_VERSION variable definition from line ~226 to line ~35 (near the top of the file, after the directory
   definitions).

  This is just a code reorganization - the variable still has the same value (1.26.2) and will work exactly the same way. Moving it earlier in the file is actually logical since it's
   a fundamental configuration variable that might be referenced later in the makefile.

  The change is purely cosmetic and safe.```