### PR TITLE
Kind image updater changes

### DIFF
--- a/.github/workflows/kind-images-upgrade.yaml
+++ b/.github/workflows/kind-images-upgrade.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           git config --global user.name "cert-manager-bot"
           git config --global user.email "cert-manager-bot@users.noreply.github.com"
-          git add -A && git commit -m "BOT: run 'make upgrade-klone' and 'make generate'" --signoff
+          git add -A && git commit -m "BOT: run 'make upgrade-kind-images'" --signoff
           git push -f origin "$SELF_UPGRADE_BRANCH"
 
       - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
@@ -92,6 +92,5 @@ jobs:
                 owner,
                 repo,
                 issue_number: result.data.number,
-                labels: ['skip-review']
               });
             }

--- a/scripts/learn_kind_images.sh
+++ b/scripts/learn_kind_images.sh
@@ -96,8 +96,11 @@ echo "kind_image_kindversion := ${kind_version}" >> "${kind_versionfile}.tmp"
 
 echo "" >> "${kind_versionfile}.tmp"
 
+# Example literal line from kind release notes that we're trying to match in the capture below:
+# - v1.34.3: `kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48`\r\n
+
 release_json=$(curl -fsSL "https://api.github.com/repos/kubernetes-sigs/kind/releases/tags/${kind_version}"| jq '
-  [ .body  | capture("- v?1\\.(?<minor>[0-9]+)(\\.(?<patch>[0-9]+))?: `kindest/node:v(?<version>[0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9.]+)?)@sha256:(?<sha256>[A-Fa-f0-9]{64})`\r"; "g") ]
+  [ .body  | capture("- v?1\\.(?<minor>[0-9]+)(\\.(?<patch>[0-9]+))?: `kindest/node:v(?<version>[0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9.]+)?)@sha256:(?<sha256>[A-Fa-f0-9]{64})`(\\r?\\n|$)"; "g") ]
   | group_by(.minor) | map(max_by(.patch))
   | sort_by(.minor)'
 )

--- a/scripts/learn_kind_images.sh
+++ b/scripts/learn_kind_images.sh
@@ -97,7 +97,7 @@ echo "kind_image_kindversion := ${kind_version}" >> "${kind_versionfile}.tmp"
 echo "" >> "${kind_versionfile}.tmp"
 
 release_json=$(curl -fsSL "https://api.github.com/repos/kubernetes-sigs/kind/releases/tags/${kind_version}"| jq '
-  [ .body  | capture("- v?1\\.(?<minor>[0-9]+)(.(?<patch>[0-9]+))?: `kindest/node:v(?<version>[^@]+)@sha256:(?<sha256>[^`]+)`\r"; "g") ]
+  [ .body  | capture("- v?1\\.(?<minor>[0-9]+)(\\.(?<patch>[0-9]+))?: `kindest/node:v(?<version>[0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9.]+)?)@sha256:(?<sha256>[A-Fa-f0-9]{64})`\r"; "g") ]
   | group_by(.minor) | map(max_by(.patch))
   | sort_by(.minor)'
 )


### PR DESCRIPTION
1. Fix commit description of kind-images-upgrade job
2. Remove skip-review from kind-images-upgrade PR, since the source of the kind images is a free-input release note that could contain anything. Someone should review to be sure.
3. Tighten regex rules so that we only accept things that look like version numbers and SHA256SUMs (AI-generated regexes)