### PR TITLE
Renovate ungroup problematic upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,6 +86,14 @@
       ],
     },
     {
+      // FIXME: Ungroup some currently problematic dependencies
+      groupName: null,
+      matchPackageNames: [
+        'github.com/google/go-containerregistry', // Release v0.21.6 was creating a havoc in our Prow cluster
+        'hashicorp/vault', // Missing binaries in the latest release (v2.0.1), see https://developer.hashicorp.com/vault/docs/updates/release-notes#vault-2-0-1
+      ],
+    },
+    {
       matchPackageNames: [
         'github.com/inteon/go-licenses/**', // FIXME(inteon): See if we can get back to upstream go-licenses
       ],


### PR DESCRIPTION
Mainly to temporarily unblock https://github.com/cert-manager/makefile-modules/pull/616.