### PR TITLE
Allow auto-merge of Renovate makefile-modules PRs

### DIFF
--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -32,6 +32,9 @@
           "make generate"
         ],
         "executionMode": "branch",
+        addLabels: [
+          'skip-review', // Adding label to allow PRs to automerge
+        ]
       }
     },
     {


### PR DESCRIPTION
We used to have auto-merge enabled for the makefile-modules upgrades ("self upgrade"). This change should add the `skip-review` label to these new PRs from Renovate, reestablishing the usual behavior.