### PR TITLE
Fix addLabels in Renovate config

### DIFF
--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -32,10 +32,10 @@
           "make generate"
         ],
         "executionMode": "branch",
-        addLabels: [
-          'skip-review', // Adding label to allow PRs to automerge
-        ]
-      }
+      },
+      addLabels: [
+        'skip-review', // Adding label to allow PRs to automerge
+      ],
     },
     {
       matchFileNames: [


### PR DESCRIPTION
This is correcting a bug in https://github.com/cert-manager/makefile-modules/pull/643. I unintentionally put the new `addLabels` field under `postUpgradeTasks`, which is obviously wrong.